### PR TITLE
add strict module layout rule

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -94,6 +94,7 @@
         {Credo.Check.Readability.RedundantBlankLines, []},
         {Credo.Check.Readability.Semicolons, []},
         {Credo.Check.Readability.SpaceAfterCommas, []},
+        {Credo.Check.Readability.StrictModuleLayout, []},
         {Credo.Check.Readability.StringSigils, []},
         {Credo.Check.Readability.TrailingBlankLine, []},
         {Credo.Check.Readability.TrailingWhiteSpace, []},

--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -2,6 +2,12 @@ defmodule ShopifyAPI.App do
   @moduledoc """
     ShopifyAPI.App contains logic and a struct for representing a Shopify App.
   """
+
+  alias ShopifyAPI.AuthRequest
+  alias ShopifyAPI.JSONSerializer
+
+  require Logger
+
   @derive {Jason.Encoder,
            only: [:name, :client_id, :client_secret, :auth_redirect_uri, :nonce, :scope]}
   defstruct name: "",
@@ -22,10 +28,6 @@ defmodule ShopifyAPI.App do
           nonce: String.t(),
           scope: String.t()
         }
-
-  require Logger
-  alias ShopifyAPI.AuthRequest
-  alias ShopifyAPI.JSONSerializer
 
   @doc """
     Generates the install URL for an App and a Shop.
@@ -72,9 +74,11 @@ defmodule ShopifyAPI.AuthRequest do
     AuthRequest.post/3 contains logic to request AuthTokens from Shopify given an App,
     Shop domain, and the auth code from the App install.
   """
-  require Logger
 
   alias ShopifyAPI.JSONSerializer
+
+  require Logger
+
   @headers [{"Content-Type", "application/json"}]
 
   defp access_token_url(domain), do: "#{ShopifyAPI.transport()}#{domain}/admin/oauth/access_token"

--- a/lib/shopify_api/bulk/cancel.ex
+++ b/lib/shopify_api/bulk/cancel.ex
@@ -1,8 +1,8 @@
 defmodule ShopifyAPI.Bulk.Cancel do
-  require Logger
-
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.Bulk.Query
+
+  require Logger
 
   @polling_timeout_message "BulkFetch timed out before completion"
   @auto_cancel_sleep_duration 1_000

--- a/lib/shopify_api/conn_helpers.ex
+++ b/lib/shopify_api/conn_helpers.ex
@@ -1,9 +1,10 @@
 defmodule ShopifyAPI.ConnHelpers do
   @moduledoc false
-  require Logger
 
   alias Plug.Conn
   alias ShopifyAPI.{App, AppServer, AuthTokenServer, Security, Shop, ShopServer}
+
+  require Logger
 
   @shopify_shop_header "x-shopify-shop-domain"
   @shopify_topics_header "x-shopify-topic"

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -3,11 +3,11 @@ defmodule ShopifyAPI.GraphQL do
   Interface to Shopify's GraphQL Admin API.
   """
 
-  require Logger
-
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.GraphQL.{JSONParseError, Response, Telemetry}
   alias ShopifyAPI.JSONSerializer
+
+  require Logger
 
   @default_graphql_version "2020-10"
 

--- a/lib/shopify_api/graphql/telemetry.ex
+++ b/lib/shopify_api/graphql/telemetry.ex
@@ -2,6 +2,7 @@ defmodule ShopifyAPI.GraphQL.Telemetry do
   @moduledoc """
   Helper module handle instrumentation with telemetry
   """
+
   alias HTTPoison.Error
   alias ShopifyAPI.GraphQL.Response
 

--- a/lib/shopify_api/plugs/admin_authenticator.ex
+++ b/lib/shopify_api/plugs/admin_authenticator.ex
@@ -22,8 +22,10 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   end
   ```
   """
+
   import Plug.Conn
   import ShopifyAPI.ConnHelpers
+
   require Logger
 
   @session_key :shopify_api_admin_authenticated

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -4,12 +4,14 @@ defmodule ShopifyAPI.Plugs.Webhook do
   get fired off to the :shopify_api :webhook_filter {module, function, _} setting getting passed a
   ShopifyAPI.EventPipe.Event.t.
   """
+
   import Plug.Conn
-  require Logger
 
   alias Plug.Conn
   alias ShopifyAPI.{ConnHelpers, JSONSerializer, Security}
   alias ShopifyAPI.EventPipe.Event
+
+  require Logger
 
   def init(opts), do: opts
 

--- a/lib/shopify_api/rate_limiting/graphql_tracker.ex
+++ b/lib/shopify_api/rate_limiting/graphql_tracker.ex
@@ -3,10 +3,10 @@ defmodule ShopifyAPI.RateLimiting.GraphQLTracker do
   Handles Tracking of GraphQL API throttling and when the API will be available for a request.
   """
 
+  @behaviour ShopifyAPI.RateLimiting.Tracker
+
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.RateLimiting
-
-  @behaviour RateLimiting.Tracker
 
   @name :shopify_api_graphql_availability_tracker
 

--- a/lib/shopify_api/rate_limiting/rest_tracker.ex
+++ b/lib/shopify_api/rate_limiting/rest_tracker.ex
@@ -2,9 +2,10 @@ defmodule ShopifyAPI.RateLimiting.RESTTracker do
   @moduledoc """
   Handles Tracking of API throttling and when the API will be available for a request.
   """
-  alias ShopifyAPI.RateLimiting
 
-  @behaviour RateLimiting.Tracker
+  @behaviour ShopifyAPI.RateLimiting.Tracker
+
+  alias ShopifyAPI.RateLimiting
 
   @name :shopify_api_rest_availability_tracker
 

--- a/lib/shopify_api/rest/checkout.ex
+++ b/lib/shopify_api/rest/checkout.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.REST.Checkout do
   Shopify REST API Checkout resources.
   """
 
-  require Logger
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Return a single checkout resource.

--- a/lib/shopify_api/rest/customer.ex
+++ b/lib/shopify_api/rest/customer.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.REST.Customer do
   Shopify REST API Customer resource
   """
 
-  require Logger
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Returns all the customers.

--- a/lib/shopify_api/rest/customer_address.ex
+++ b/lib/shopify_api/rest/customer_address.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.REST.CustomerAddress do
   Shopify REST API Customer Address resources.
   """
 
-  require Logger
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Return a list of all addresses for a customer.

--- a/lib/shopify_api/rest/inventory_item.ex
+++ b/lib/shopify_api/rest/inventory_item.ex
@@ -2,9 +2,11 @@ defmodule ShopifyAPI.REST.InventoryItem do
   @moduledoc """
   ShopifyAPI REST API InventoryItem resource
   """
-  require Logger
+
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Return a list of inventory items.

--- a/lib/shopify_api/rest/location.ex
+++ b/lib/shopify_api/rest/location.ex
@@ -2,9 +2,11 @@ defmodule ShopifyAPI.REST.Location do
   @moduledoc """
   ShopifyAPI REST API Location resource
   """
-  require Logger
+
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Return a list of locations.

--- a/lib/shopify_api/rest/marketing_event.ex
+++ b/lib/shopify_api/rest/marketing_event.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.REST.MarketingEvent do
   ShopifyAPI REST API MarketingEvent resource
   """
 
-  require Logger
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Return a list of all marketing events.

--- a/lib/shopify_api/rest/metafield.ex
+++ b/lib/shopify_api/rest/metafield.ex
@@ -1,16 +1,16 @@
 defmodule ShopifyAPI.REST.Metafield do
-  @enforce_keys [:key, :namespace, :value, :value_type]
-  defstruct key: "",
-            namespace: "",
-            value: 0,
-            value_type: ""
-
   @moduledoc """
   ShopifyAPI REST API Metafield resource
   """
 
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  @enforce_keys [:key, :namespace, :value, :value_type]
+  defstruct key: "",
+            namespace: "",
+            value: 0,
+            value_type: ""
 
   @doc """
   Get a list of all metafields that belong to a resource.

--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
   ShopifyAPI REST API Recurring Application Charge resource
   """
 
-  require Logger
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.REST
+
+  require Logger
 
   @doc """
   Create a recurring application charge.

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -7,10 +7,11 @@ defmodule ShopifyAPI.REST.Request do
   """
 
   use HTTPoison.Base
-  require Logger
 
   alias HTTPoison.Error
   alias ShopifyAPI.{AuthToken, JSONSerializer, RateLimiting, Throttled}
+
+  require Logger
 
   @default_api_version "2020-10"
 

--- a/lib/shopify_api/router.ex
+++ b/lib/shopify_api/router.ex
@@ -1,10 +1,11 @@
 defmodule ShopifyAPI.Router do
   use Plug.Router
-  require Logger
 
   alias Plug.Conn
   alias ShopifyAPI.{App, AuthToken, AuthTokenServer, ConnHelpers}
   alias ShopifyAPI.Shop
+
+  require Logger
 
   plug(:match)
   plug(:dispatch)

--- a/lib/shopify_api/throttled.ex
+++ b/lib/shopify_api/throttled.ex
@@ -20,9 +20,10 @@ defmodule ShopifyAPI.Throttled do
   request will be retried after a delay and re-check of the ets table, to a
   maximum of 10 total attempts (this is configurable).
   """
-  require Logger
 
   alias ShopifyAPI.RateLimiting
+
+  require Logger
 
   @request_max_tries 10
 


### PR DESCRIPTION
This gives us a consistent layout for the top of a module, we are using the default order provided by credo.

          defmodule MyMod do
            @moduledoc "moduledoc"
            use Foo
            import Bar
            alias Baz
            require Qux
          end