### PR TITLE
add Bulk async_exec!/2, returns the bulk_query_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- New Bulk.Query.async_exec!/2 returns bulk_query_id, useful for when using the
+  bulk query completed webhook.
 - Add `Bulk.process_stream_from_id!/2`
   - intended for use after receiving a `bulk_operations/finish` webhook
 


### PR DESCRIPTION
- useful when using the bulk query completed webhook