### PR TITLE
ver bump to 0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.13.7
+
 - New Bulk.Query.async_exec!/2 returns bulk_query_id, useful for when using the
   bulk query completed webhook.
 - Add `Bulk.process_stream_from_id!/2`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.13.6"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.13.7"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.13.5"
+  @version "0.13.7"
 
   def project do
     [


### PR DESCRIPTION
- New Bulk.Query.async_exec!/2 returns bulk_query_id, useful for when using the bulk query completed webhook.
- Add `Bulk.process_stream_from_id!/2`
  - intended for use after receiving a `bulk_operations/finish` webhook