### PR TITLE
Add ShopServer.delete/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Add ShopServer.delete/1
 
 ## 0.14.0
 - Add 401 unauthorized response to Webhook plug

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -32,6 +32,13 @@ defmodule ShopifyAPI.ShopServer do
     end
   end
 
+  @spec delete(String.t()) :: :ok
+  def delete(domain) do
+    true = :ets.delete(@table, domain)
+
+    :ok
+  end
+
   ## GenServer Callbacks
 
   def start_link(_opts) do


### PR DESCRIPTION
With the new mandatory GDPR webhook topic `shop/redact`, you may want to delete a shop from the shop server. 