### PR TITLE
Remove using the session from the AdminAuthenticator plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Remove usage of session and session rehydration from AdminAuthenticator plug.
 
 ## 0.14.0
 - Add 401 unauthorized response to Webhook plug

--- a/lib/shopify_api/plugs/admin_authenticator.ex
+++ b/lib/shopify_api/plugs/admin_authenticator.ex
@@ -28,61 +28,26 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   require Logger
 
   @shopify_shop_header "x-shopify-shop-domain"
-  @session_key :shopify_api_admin_authenticated
   @defaults [shopify_mount_path: "/shop"]
 
   def init(opts), do: Keyword.merge(opts, @defaults)
 
   def call(conn, options) do
-    if Conn.get_session(conn, @session_key) do
-      rehydrate_session(conn)
-    else
-      do_authentication(conn, options)
-    end
-  end
-
-  defp rehydrate_session(conn) do
-    with app_name <- Conn.get_session(conn, :app_name),
-         myshopify_domain <- Conn.get_session(conn, :shop_domain),
-         {:ok, app} <- ShopifyAPI.AppServer.get(app_name),
-         {:ok, shop} <- ShopifyAPI.ShopServer.get(myshopify_domain),
-         {:ok, auth_token} <- ShopifyAPI.AuthTokenServer.get(myshopify_domain, app_name) do
-      conn
-      |> assign_app(app)
-      |> assign_shop(shop)
-      |> assign_auth_token(auth_token)
-    else
-      error ->
-        Logger.debug("Failed to rehydrate session #{inspect(error)}")
-
-        conn
-        |> Conn.delete_session(@session_key)
-        |> Conn.resp(401, "Not Authorized.")
-        |> Conn.halt()
-    end
-  end
-
-  defp do_authentication(conn, options) do
     with app_name <- conn.params["app"] || List.last(conn.path_info),
          {:ok, app} <- ShopifyAPI.AppServer.get(app_name),
          true <- valid_hmac?(app, conn.query_params),
          myshopify_domain <- shop_domain_from_conn(conn),
          {:ok, shop} <- ShopifyAPI.ShopServer.get(myshopify_domain),
          {:ok, auth_token} <- ShopifyAPI.AuthTokenServer.get(myshopify_domain, app_name) do
-      # store the App and Shop name in the session for use on other page views
       conn
       |> assign_app(app)
       |> assign_shop(shop)
       |> assign_auth_token(auth_token)
-      |> Conn.put_session(:app_name, app_name)
-      |> Conn.put_session(:shop_domain, myshopify_domain)
-      |> Conn.put_session(@session_key, true)
     else
       false ->
         Logger.info("#{__MODULE__} failed hmac validation")
 
         conn
-        |> Conn.delete_session(@session_key)
         |> Conn.resp(401, "Not Authorized.")
         |> Conn.halt()
 


### PR DESCRIPTION
Shopify no longer allows third party cookies here and will reject your app if you introduce them. 

This plug should no longer be in a pipeline that fetches the session. Attempting to access the session when it has not been fetched crashes. Hence, this PR removes usage of the session from the plug.