### PR TITLE
Relax telemetry requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.14.2
+
 - Relax telemetry requirement to still include 0.4
 
 ## 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Relax telemetry requirement to still include 0.4
+
 ## 0.14.1
 
 - Take advantage of increased admin API rate limits for plus shops https://shopify.dev/changelog/increased-admin-api-rate-limits-for-shopify-plus

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.14.1"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.14.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.14.1"
+  @version "0.14.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Plug.ShopifyAPI.MixProject do
       {:jason, "~> 1.0"},
       {:jose, "~> 1.11.2"},
       {:plug, "~> 1.0"},
-      {:telemetry, "~> 1.0"}
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
Eases the upgrade path. There were [no code changes in the 1.0 release](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100) and it's a common pattern for deps to be cool with either 0.4 or 1.0 ([ecto, for example](https://github.com/elixir-ecto/ecto/blob/master/mix.exs#L35))