### PR TITLE
Add AdminAuthenticator passing conn through if there is no HMAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- AdminAuthenticator plug passes through if there is no hmac
+
 ## 0.14.2
 
 - Relax telemetry requirement to still include 0.4

--- a/lib/shopify_api/plugs/admin_authenticator.ex
+++ b/lib/shopify_api/plugs/admin_authenticator.ex
@@ -5,7 +5,10 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   on admin page load, and set a session cookie for the duration of the session.
 
   The plug will assign the Shop, App and AuthToken to the Conn for easy access in your
-  admin controller.
+  admin controller when the a valid hmac is provided.
+
+  When no HMAC is provided, the plug passes through without assigning the Shop, App and AuthToken.
+  Shopify expects this behaviour and has started rejecting new apps that do not behave this way.
 
   Make sure to include the App name in the path, in our example it is included directly in the
   path `"/shop-admin/:app"`.
@@ -25,6 +28,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   ```
   """
   alias Plug.Conn
+
   require Logger
 
   @shopify_shop_header "x-shopify-shop-domain"
@@ -33,18 +37,26 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   def init(opts), do: Keyword.merge(opts, @defaults)
 
   def call(conn, options) do
-    with app_name <- conn.params["app"] || List.last(conn.path_info),
+    do_authentication(conn, options)
+  end
+
+  defp do_authentication(conn, options) do
+    with :ok <- has_hmac(conn.query_params),
+         app_name <- conn.params["app"] || List.last(conn.path_info),
          {:ok, app} <- ShopifyAPI.AppServer.get(app_name),
-         true <- valid_hmac?(app, conn.query_params),
+         :ok <- validate_hmac(app, conn.query_params),
          myshopify_domain <- shop_domain_from_conn(conn),
-         {:ok, shop} <- ShopifyAPI.ShopServer.get(myshopify_domain),
+         {:ok, shop} <- fetch_shop(myshopify_domain),
          {:ok, auth_token} <- ShopifyAPI.AuthTokenServer.get(myshopify_domain, app_name) do
       conn
       |> assign_app(app)
       |> assign_shop(shop)
       |> assign_auth_token(auth_token)
     else
-      false ->
+      {:error, :no_hmac} ->
+        conn
+
+      {:error, :invalid_hmac} ->
         Logger.info("#{__MODULE__} failed hmac validation")
 
         conn
@@ -52,11 +64,14 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
         |> Conn.halt()
 
       # Try redirecting to the install path
-      _ ->
+      {:error, :shop_not_found} ->
         conn
         |> Conn.resp(:found, "")
         |> Conn.put_resp_header("location", install_path(options, conn))
         |> Conn.halt()
+
+      _ ->
+        conn
     end
   end
 
@@ -69,13 +84,28 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   defp shop_domain_from_header(conn),
     do: conn |> Conn.get_req_header(@shopify_shop_header) |> List.first()
 
-  defp valid_hmac?(%ShopifyAPI.App{client_secret: secret}, params) do
-    params["hmac"] ==
-      params
-      |> Enum.reject(fn {key, _} -> key == "hmac" or key == "signature" end)
-      |> Enum.sort_by(&elem(&1, 0))
-      |> Enum.map_join("&", fn {key, value} -> key <> "=" <> value end)
-      |> ShopifyAPI.Security.base16_sha256_hmac(secret)
+  defp has_hmac(%{"hmac" => hmac}) when is_binary(hmac), do: :ok
+  defp has_hmac(_params), do: {:error, :no_hmac}
+
+  defp validate_hmac(%ShopifyAPI.App{client_secret: secret}, params) do
+    request_hmac = params["hmac"]
+
+    params
+    |> Enum.reject(fn {key, _} -> key == "hmac" or key == "signature" end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map_join("&", fn {key, value} -> key <> "=" <> value end)
+    |> ShopifyAPI.Security.base16_sha256_hmac(secret)
+    |> then(fn
+      ^request_hmac -> :ok
+      _ -> {:error, :invalid_hmac}
+    end)
+  end
+
+  defp fetch_shop(myshopify_domain) do
+    case ShopifyAPI.ShopServer.get(myshopify_domain) do
+      {:ok, shop} -> {:ok, shop}
+      :error -> {:error, :shop_not_found}
+    end
   end
 
   defp install_path(options, conn) do

--- a/test/shopify_api/plugs/admin_authenticator_test.exs
+++ b/test/shopify_api/plugs/admin_authenticator_test.exs
@@ -95,4 +95,25 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticatorTest do
              ]
     end
   end
+
+  describe "without an hmac" do
+    setup do
+      params = %{shop: @uninstalled_shop}
+
+      # Create a test connection
+      conn =
+        :get
+        |> conn("/admin/#{@app.name}?" <> URI.encode_query(params))
+        |> init_test_session(%{})
+        |> Conn.fetch_query_params()
+
+      [conn: conn]
+    end
+
+    test "plug does not halt", %{conn: conn} do
+      conn = AdminAuthenticator.call(conn, shopify_mount_path: "/shop")
+
+      refute conn.halted
+    end
+  end
 end


### PR DESCRIPTION
When no HMAC is provided, shopify expects that you still server up the resource. They have started rejecting apps that do not do this.