### PR TITLE
Lowercase response headers to fix matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: REST pagination broken
+
 ## 0.15.5
 
 - Fix: UserTokenServer.delete wasn't using the correct key in to the :ets table

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -246,7 +246,8 @@ defmodule ShopifyAPI.REST.Request do
 
   @spec extract_next_link(list) :: binary | nil
   defp extract_next_link(headers) do
-    for {"Link", link_header} <- headers,
+    for {header, link_header} <- headers,
+        String.downcase(header) == "link",
         links <- String.split(link_header, ",") do
       case Regex.named_captures(@link_regex, links) do
         %{"link" => link, "rel" => "next"} -> link

--- a/test/shopify_api/rest_test.exs
+++ b/test/shopify_api/rest_test.exs
@@ -116,4 +116,33 @@ defmodule ShopifyAPI.RESTTest do
       assert {:error, %{status_code: 404}} = REST.delete(token, "example")
     end
   end
+
+  describe "extract_results_and_next_link" do
+    test "returns next link if found" do
+      headers = [{"Link", "<https://example.com?page=2>; rel=\"next\""}]
+      response = %HTTPoison.Response{body: "", headers: headers}
+      {_, next_link} = Request.extract_results_and_next_link(response)
+      assert next_link == "https://example.com?page=2"
+    end
+
+    test "returns nil if next link not found" do
+      headers = [{"Link", "<https://example.com?page=1>; rel=\"prev\""}]
+      response = %HTTPoison.Response{body: "", headers: headers}
+      {_, next_link} = Request.extract_results_and_next_link(response)
+      assert next_link == nil
+    end
+
+    test "returns nil if headers are empty" do
+      response = %HTTPoison.Response{body: "", headers: []}
+      {_, next_link} = Request.extract_results_and_next_link(response)
+      assert next_link == nil
+    end
+
+    test "returns nil if 'Link' header is missing" do
+      headers = [{"Content-Type", "application/json"}]
+      response = %HTTPoison.Response{body: "", headers: headers}
+      {_, next_link} = Request.extract_results_and_next_link(response)
+      assert next_link == nil
+    end
+  end
 end


### PR DESCRIPTION
## What does this do?
It fixes broken pagination.
## How does this change work?
Setting the header key name to a downcase and checking with that rather than matching it on the 'Link' string.
## How do you manually test this?
Retrieve Shopify resource data exceeding the default pagination limit of 50 records using a REST call, like `ShopifyAPI.REST.Product.all` and verify that the response includes all the expected records.
## When should this be merged?
Sooner the better
