### PR TITLE
Add Scopes context and Scope protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: 0.16.2 broke the installation path when no JWT was passed along
 - New: Reworked webhook flow, [check readme](README.md#Webhooks) for details on how to use
 - Deprecation: old Plugs.Webhook is being replaced and will be removed eventually
+- New: Add Scopes context and Scope protocol. Change GraphQL queries to expect scopes. AuthToken can be used as a scope as a fallback via the defimpl in the AuthToken file.
 
 ## 0.16.2
 

--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -16,14 +16,14 @@ defmodule ShopifyAPI do
       iex> estimated_cost = 10
       iex> variables = %{input: %{id: "gid://shopify/Metafield/9208558682200"}}
       iex> options = [debug: true]
-      iex> ShopifyAPI.graphql_request(auth_token, query, estimated_cost, variables, options)
+      iex> ShopifyAPI.graphql_request(scope, query, estimated_cost, variables, options)
       {:ok, %ShopifyAPI.GraphQL.Response{...}}
   """
-  @spec graphql_request(ShopifyAPI.AuthToken.t(), String.t(), integer(), map(), list()) ::
+  @spec graphql_request(ShopifyAPI.Scope.t(), String.t(), integer(), map(), list()) ::
           ShopifyAPI.GraphQL.query_response()
-  def graphql_request(token, query, estimated_cost, variables \\ %{}, opts \\ []) do
-    func = fn -> ShopifyAPI.GraphQL.query(token, query, variables, opts) end
-    Throttled.graphql_request(func, token, estimated_cost)
+  def graphql_request(scope, query, estimated_cost, variables \\ %{}, opts \\ []) do
+    func = fn -> ShopifyAPI.GraphQL.query(scope, query, variables, opts) end
+    Throttled.graphql_request(func, scope, estimated_cost)
   end
 
   def request(token, func), do: Throttled.request(func, token, RateLimiting.RESTTracker)
@@ -47,8 +47,8 @@ defmodule ShopifyAPI do
   depending on if you enable user_user_tokens.
   """
   @spec shopify_oauth_url(ShopifyAPI.App.t(), String.t(), list()) :: String.t()
-  def shopify_oauth_url(app, domain, opts \\ [])
-      when is_struct(app, ShopifyAPI.App) and is_binary(domain) and is_list(opts) do
+  def shopify_oauth_url(%ShopifyAPI.App{} = app, domain, opts \\ [])
+      when is_binary(domain) and is_list(opts) do
     opts = Keyword.merge(@oauth_default_options, opts)
     user_token_query_params = opts |> Keyword.get(:use_user_tokens) |> per_user_query_params()
     query_params = oauth_query_params(app) ++ user_token_query_params

--- a/lib/shopify_api/auth_token.ex
+++ b/lib/shopify_api/auth_token.ex
@@ -46,3 +46,29 @@ defmodule ShopifyAPI.AuthToken do
     new(app, myshopify_domain, code, attrs["access_token"])
   end
 end
+
+defimpl ShopifyAPI.Scope, for: ShopifyAPI.AuthToken do
+  def shop(auth_token) do
+    case ShopifyAPI.ShopServer.get(auth_token.shop_name) do
+      {:ok, shop} ->
+        shop
+
+      _ ->
+        raise "Failed to find Shop for Scope out of AuthToken #{auth_token.shop_name} in ShopServer"
+    end
+  end
+
+  def app(auth_token) do
+    case ShopifyAPI.AppServer.get(auth_token.app_name) do
+      {:ok, app} ->
+        app
+
+      _ ->
+        raise "Failed to find App for Scope out of AuthToken #{auth_token.app_name} in AppServer"
+    end
+  end
+
+  def auth_token(auth_token), do: auth_token
+
+  def user_token(_auth_token), do: nil
+end

--- a/lib/shopify_api/graphql/telemetry.ex
+++ b/lib/shopify_api/graphql/telemetry.ex
@@ -4,16 +4,17 @@ defmodule ShopifyAPI.GraphQL.Telemetry do
   """
   alias HTTPoison.Error
   alias ShopifyAPI.GraphQL.Response
+  alias ShopifyAPI.Scopes
 
   def send(
         module_name,
-        %{app_name: app, shop_name: shop} = _token,
+        scope,
         time,
         {:ok, %Response{response: response}} = _response
       ) do
     metadata = %{
-      app: app,
-      shop: shop,
+      app: Scopes.app(scope),
+      shop: Scopes.shop(scope),
       module: module_name,
       response: response
     }
@@ -23,7 +24,7 @@ defmodule ShopifyAPI.GraphQL.Telemetry do
 
   def send(
         module_name,
-        %{app_name: app, shop_name: shop} = _token,
+        scope,
         time,
         response
       ) do
@@ -34,8 +35,8 @@ defmodule ShopifyAPI.GraphQL.Telemetry do
       end
 
     metadata = %{
-      app: app,
-      shop: shop,
+      app: Scopes.app(scope),
+      shop: Scopes.shop(scope),
       module: module_name,
       reason: reason
     }

--- a/lib/shopify_api/model/webhook_scope.ex
+++ b/lib/shopify_api/model/webhook_scope.ex
@@ -20,3 +20,20 @@ defmodule ShopifyAPI.Model.WebhookScope do
     :shop
   ]
 end
+
+defimpl ShopifyAPI.Scope, for: ShopifyAPI.Model.WebhoookScope do
+  def shop(%{shop: shop}), do: shop
+  def app(%{app: app}), do: app
+
+  def auth_token(%{app: app, shop: shop}) do
+    case ShopifyAPI.AuthTokenServer.get(shop, app) do
+      {:ok, token} ->
+        token
+
+      _ ->
+        raise "Failed to find AuthToken for Scope out of WebhookScope #{shop.domain} #{app.name} in AuthTokenServer"
+    end
+  end
+
+  def user_token(_auth_token), do: nil
+end

--- a/lib/shopify_api/scope.ex
+++ b/lib/shopify_api/scope.ex
@@ -1,0 +1,26 @@
+defprotocol ShopifyAPI.Scope do
+  @fallback_to_any true
+
+  @spec auth_token(__MODULE__.t()) :: ShopifyAPI.AuthToken.t()
+  def auth_token(scope)
+
+  @spec user_token(__MODULE__.t()) :: ShopifyAPI.UserToken.t() | nil
+  def user_token(scope)
+
+  @spec shop(__MODULE__.t()) :: ShopifyAPI.Shop.t()
+  def shop(scope)
+
+  @spec app(__MODULE__.t()) :: ShopifyAPI.App.t()
+  def app(scope)
+end
+
+defimpl ShopifyAPI.Scope, for: Any do
+  def shop(%{shop: shop}), do: shop
+
+  def app(%{app: app}), do: app
+
+  def auth_token(%{auth_token: auth_token}), do: auth_token
+
+  def user_token(%{user_token: %ShopifyAPI.UserToken{} = user_token}), do: user_token
+  def user_token(_), do: nil
+end

--- a/lib/shopify_api/scopes.ex
+++ b/lib/shopify_api/scopes.ex
@@ -1,0 +1,55 @@
+defmodule ShopifyAPI.Scopes do
+  alias ShopifyAPI.Scope
+
+  @spec shop(Scope.t()) :: ShopifyAPI.Shop.t()
+  def shop(scope), do: Scope.shop(scope)
+
+  @spec app(Scope.t()) :: ShopifyAPI.App.t()
+  def app(scope), do: Scope.app(scope)
+
+  @spec auth_token(Scope.t()) :: ShopifyAPI.AuthToken.t()
+  def auth_token(scope), do: Scope.auth_token(scope)
+
+  @spec user_token(Scope.t()) :: ShopifyAPI.UserToken.t() | nil
+  def user_token(scope), do: Scope.user_token(scope)
+
+  @spec myshopify_domain(Scope.t()) :: String.t()
+  def myshopify_domain(scope), do: shop(scope).domain
+
+  @spec shop_slug(Scope.t()) :: String.t()
+  def shop_slug(scope), do: scope |> myshopify_domain() |> ShopifyAPI.Shop.slug_from_domain()
+
+  @spec app_name(Scope.t()) :: String.t()
+  def app_name(scope), do: Scope.app(scope).name
+
+  @spec app_handle(Scope.t()) :: String.t()
+  def app_handle(scope), do: Scope.app(scope).handle
+
+  @doc """
+  Accessor for either the User's Token (aka online token) falling back
+  to the Shop's Token (aka offline token)
+
+  ## Examples
+      iex> %{user_token: %ShopifyAPI.UserToken{token: "ftw"}} |> ShopifyAPI.Scopes.access_token()
+      "ftw"
+
+      iex> %{user_token: %ShopifyAPI.UserToken{token: "wtf"}, auth_token: %ShopifyAPI.AuthToken{token: "foo"}} |> ShopifyAPI.Scopes.access_token()
+      "wtf"
+
+      iex> %{user_token: nil, auth_token: %ShopifyAPI.AuthToken{token: "foo"}} |> ShopifyAPI.Scopes.access_token()
+      "foo"
+
+      iex> %{auth_token: %ShopifyAPI.AuthToken{token: "bar"}} |> ShopifyAPI.Scopes.access_token()
+      "bar"
+  """
+  @spec access_token(Scope.t()) :: String.t()
+  def access_token(scope) do
+    token =
+      case user_token(scope) do
+        user_token = %ShopifyAPI.UserToken{} -> user_token
+        _ -> auth_token(scope)
+      end
+
+    token.token
+  end
+end

--- a/test/shopify_api/graphql/graphql_test.exs
+++ b/test/shopify_api/graphql/graphql_test.exs
@@ -1,10 +1,14 @@
 defmodule ShopifyAPI.GraphQL.GraphQLTest do
   use ExUnit.Case
 
+  import ShopifyAPI.Factory
+  import ShopifyAPI.SessionTokenSetup
+
   alias Plug.Conn
-  alias ShopifyAPI.{AuthToken, JSONSerializer, Shop}
+
   alias ShopifyAPI.GraphQL
   alias ShopifyAPI.GraphQL.Response
+  alias ShopifyAPI.JSONSerializer
 
   @data %{
     "metafield1" => %{
@@ -52,22 +56,16 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
 
   setup _context do
     bypass = Bypass.open()
-
-    token = %AuthToken{
-      token: "1234",
-      shop_name: "localhost:#{bypass.port}"
-    }
-
-    shop = %Shop{domain: "localhost:#{bypass.port}"}
-
-    {:ok, %{bypass: bypass, auth_token: token, shop: shop}}
+    {:ok, [bypass: bypass, shop: build(:shop, domain: "localhost:#{bypass.port}")]}
   end
+
+  setup [:offline_token]
 
   describe "GraphQL query/2" do
     test "when mutation has parametized variables", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
 
@@ -88,7 +86,7 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
     test "when mutation is a query string", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
 
@@ -109,7 +107,7 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
     test "when deleting a metafield that does not exist", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       response = Map.merge(%{"data" => @data_does_not_exist}, %{"extensions" => @metadata})
 
@@ -131,7 +129,7 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
     test "when query exceeds max cost for 1000", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       Bypass.expect_once(
         bypass,
@@ -151,7 +149,7 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
     test "when response contains metadata", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
 
@@ -180,7 +178,7 @@ defmodule ShopifyAPI.GraphQL.GraphQLTest do
     test "when response does not contain metadata", %{
       bypass: bypass,
       shop: _shop,
-      auth_token: token
+      offline_token: token
     } do
       Bypass.expect_once(
         bypass,

--- a/test/shopify_api/graphql/telemetry_test.exs
+++ b/test/shopify_api/graphql/telemetry_test.exs
@@ -1,33 +1,27 @@
 defmodule ShopifyAPI.GraphQL.TelemetryTest do
   use ExUnit.Case
 
+  import ShopifyAPI.SessionTokenSetup
+
   alias HTTPoison.Error
-  alias ShopifyAPI.AuthToken
   alias ShopifyAPI.GraphQL.{Response, Telemetry}
 
   @module "module"
   @time 1202
 
-  setup _context do
-    token = %AuthToken{
-      token: "1234",
-      shop_name: "localhost"
-    }
-
-    {:ok, %{auth_token: token}}
-  end
+  setup [:offline_token]
 
   describe "Telemetry send/4" do
-    test "when graphql response is succesful", %{auth_token: token} do
+    test "when graphql response is succesful", %{offline_token: token} do
       assert :ok == Telemetry.send(@module, token, @time, {:ok, %Response{response: "response"}})
     end
 
-    test "when graphql request fails", %{auth_token: token} do
+    test "when graphql request fails", %{offline_token: token} do
       assert :ok ==
                Telemetry.send(@module, token, @time, {:error, %Response{response: "response"}})
     end
 
-    test "when graphql request errors out", %{auth_token: token} do
+    test "when graphql request errors out", %{offline_token: token} do
       assert :ok == Telemetry.send(@module, token, @time, {:error, %Error{reason: "reason"}})
     end
   end

--- a/test/shopify_api/scopes_test.exs
+++ b/test/shopify_api/scopes_test.exs
@@ -1,0 +1,5 @@
+defmodule ShopifyAPI.ScopesTest do
+  use ExUnit.Case, async: true
+
+  doctest ShopifyAPI.Scopes
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,17 +16,22 @@ defmodule ShopifyAPI.Factory do
 
   def myshopify_domain, do: Faker.Internet.slug() <> ".myshopify.com"
 
-  def shop_factory do
-    domain = myshopify_domain()
-    %ShopifyAPI.Shop{domain: domain}
+  def shop_factory(params) do
+    domain = params[:domain] || myshopify_domain()
+    shop = %ShopifyAPI.Shop{domain: domain}
+    ShopifyAPI.ShopServer.set(shop)
+    shop
   end
 
   def app_factory do
-    %ShopifyAPI.App{
+    app = %ShopifyAPI.App{
       name: shopify_app_name(),
       client_id: "#{__MODULE__}.id",
       client_secret: shopify_app_secret()
     }
+
+    ShopifyAPI.AppServer.set(app)
+    app
   end
 
   def auth_token_factory(params) do

--- a/test/support/session_token_setup.ex
+++ b/test/support/session_token_setup.ex
@@ -1,14 +1,18 @@
 defmodule ShopifyAPI.SessionTokenSetup do
   import ShopifyAPI.Factory
 
-  def offline_token(%{shop: %ShopifyAPI.Shop{} = shop}) do
-    token = build(:auth_token, %{shop_name: shop.domain})
+  def offline_token(context) do
+    app = context[:app] || build(:app)
+    shop = context[:shop] || build(:shop)
+    token = build(:auth_token, %{app_name: app.name, shop_name: shop.domain})
     ShopifyAPI.AuthTokenServer.set(token)
     [offline_token: token]
   end
 
-  def online_token(%{shop: %ShopifyAPI.Shop{} = shop}) do
-    token = build(:user_token, %{shop_name: shop.domain})
+  def online_token(context) do
+    app = context[:app] || build(:app)
+    shop = context[:shop] || build(:shop)
+    token = build(:user_token, %{app_name: app.name, shop_name: shop.domain})
     ShopifyAPI.UserTokenServer.set(token)
     [online_token: token]
   end


### PR DESCRIPTION
This uses the now commonly accepted pattern of passing down a scope to requests. The protocol defines how the data from the scope can be accessed. AuthToken has an implementation of the new protocol for backwards compatibility reasons.

This changes many places where auth_token was used to instead use Scope. 