### PR TITLE
Document the auth and token-caching modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.16.6
 
-- New: Add support for passing options to `ShopifyAPI.Bulk.Query.exec/3`, with `group_objects`
+- New: Add support for passing options to `ShopifyAPI.Bulk.Query.exec!/3`, with `group_objects`
   as a new option to group the returned objects by a specified key.
 
 ## 0.16.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     - [Background Runner](#Background-Runner)
     - [Shops](#Shops)
     - [Apps](#Apps)
-    - [AuthTokens](#AuthTokens)
+    - [Auth Tokens](#auth-tokens)
   - [Webhooks](#Webhooks)
   - [GraphQL](#GraphQL)
   - [Telemetry](#Telemetry)
@@ -43,7 +43,9 @@ plug ShopifyAPI.Plugs.Webhook,
   callback: {WebhookHandler, :handle_webhook, []}
 ```
 
-If you want persisted Apps, Shops, and Tokens add configuration to your functions.
+If you want Apps, Shops, and Tokens to survive a restart, give each cache an initializer and a
+persistence hook. See [Auth Tokens](#auth-tokens) for what those hooks are handed and when.
+
 ```elixir
 config :shopify_api, ShopifyAPI.AuthTokenServer,
   initializer: {MyApp.AuthToken, :init, []},
@@ -79,11 +81,12 @@ config :shopify_api, ShopifyAPI.REST, api_version: "2019-04"
 
 ### Supervisor
 
-The ShopifyAPI has three servers for caching commonly-used structs - `AppServer`, `ShopServer`, and `AuthTokenServer`.
-These act as a write-through caching layer for their corresponding data structure.
+The ShopifyAPI has four servers for caching commonly-used structs - `AppServer`,
+`ShopServer`, `AuthTokenServer`, and `UserTokenServer`. These act as a
+write-through caching layer for their corresponding data structure.
 
-A supervisor `ShopifyAPI.Supervisor` is provided to start up and supervise all three servers.
-Add it to your application's supervision tree, and define [hooks for preloading data](#Installation).
+A supervisor `ShopifyAPI.Supervisor` is provided to start up and supervise all four servers.
+Add it to your application's supervision tree, and define [hooks for preloading data](#installation).
 
 NOTE: Make sure you place the supervisor after any dependencies used in preloading the data. (ie Ecto)
 
@@ -99,6 +102,23 @@ def start(_type, _args) do
   Supervisor.start_link(children, strategy: :one_for_one)
 end
 ```
+
+### Auth Tokens
+
+`ShopifyAPI.AuthTokenServer` caches the
+[offline access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens)
+that authenticate every REST and GraphQL call. A token is written when a shop
+installs your app and read on each request afterwards, so the cache needs to
+survive restarts: the `initializer` hook loads tokens back in at boot, and the
+`persistence` hook writes them out as they arrive.
+
+Both hooks are optional, and without them tokens live only in memory and are
+lost when the application stops.
+
+See the `ShopifyAPI.AuthTokenServer` documentation for the full contract - the
+arguments each hook receives, the traps around deleting tokens and handling app
+uninstalls, and a worked Ecto example. Per-user online tokens are handled
+separately by `ShopifyAPI.UserTokenServer`.
 
 ## Webhooks
 
@@ -137,7 +157,7 @@ Now once a shop is installed, you can create webhook subscriptions.
 This will automatically append your app's name to the generated webhook URL:
 
 ```elixir
-token = ShopifyAPI.AuthTokenServer.get("shop domain", "app name")
+{:ok, token} = ShopifyAPI.AuthTokenServer.get("shop domain", "app name")
 
 topic = "orders/create"
 server_address = ShopifyAPI.REST.Webhook.webhook_uri(token)

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,0 +1,168 @@
+# Authentication
+
+How a shop gets installed, where its credentials end up, and what authenticates
+each request afterwards.
+
+## The pieces
+
+Four structs, each cached by a matching server, all started by
+`ShopifyAPI.Supervisor`:
+
+| Struct                 | Cache                        | Keyed by            | Holds                             |
+| ---------------------- | ---------------------------- | ------------------- | --------------------------------- |
+| `ShopifyAPI.App`       | `ShopifyAPI.AppServer`       | app name            | your client id, secret and scopes |
+| `ShopifyAPI.Shop`      | `ShopifyAPI.ShopServer`      | myshopify domain    | little more than the domain       |
+| `ShopifyAPI.AuthToken` | `ShopifyAPI.AuthTokenServer` | `{shop, app}`       | the offline token API calls use   |
+| `ShopifyAPI.UserToken` | `ShopifyAPI.UserTokenServer` | `{shop, app, user}` | a staff member's online token     |
+
+The caches are ETS-backed and empty at boot. They repopulate from an
+`initializer` callback and write out through a `persistence` callback — the
+contract for both is documented on `ShopifyAPI.AuthTokenServer`. Apps come from
+your configuration or database; tokens come from installing.
+
+## Two ways to get a token
+
+**The OAuth redirect**, implemented by `ShopifyAPI.Router`. The merchant is
+bounced to Shopify, approves the scopes, and is redirected back with a `code`
+that gets exchanged for a token. This is what an app mounting the router uses.
+
+**Token exchange**, implemented by `ShopifyAPI.JWTSessionToken`. An embedded app
+already receives a signed session token on every request from App Bridge, and
+can trade it for an access token with no redirects at all.
+
+They are not exclusive. An app can mount the router for first-time installs and
+still use `ShopifyAPI.JWTSessionToken.get_offline_token/2` on request paths —
+the latter falls back to exchange only when the cache has nothing, so it is
+cheap to call.
+
+## Setting up
+
+Start the supervisor after anything its initializers need:
+
+```elixir
+def start(_type, _args) do
+  children = [MyApp.Repo, ShopifyAPI.Supervisor]
+  Supervisor.start_link(children, strategy: :one_for_one)
+end
+```
+
+Tell the caches how to load and save. Apps are usually seeded from config and
+never written back; tokens must be persisted or every restart logs your shops
+out:
+
+```elixir
+config :shopify_api, ShopifyAPI.AppServer,
+  initializer: {MyApp.ShopifyApp, :init, []}
+
+config :shopify_api, ShopifyAPI.AuthTokenServer,
+  initializer: {MyApp.AuthToken, :init, []},
+  persistence: {MyApp.AuthToken, :save, []}
+```
+
+Forward a scope to the router, and register a hook to run when a shop finishes
+authenticating:
+
+```elixir
+scope "/shop" do
+  forward("/", ShopifyAPI.Router)
+end
+```
+
+```elixir
+config :shopify_api, ShopifyAPI.Shop, post_login: {MyApp.Shop, :post_login, []}
+```
+
+## Installing a shop
+
+```
+GET /shop/install?shop=acme.myshopify.com&app=my-app
+      │
+      │  ShopifyAPI.Router looks the app up in AppServer
+      ▼
+302 → https://acme.myshopify.com/admin/oauth/authorize?...
+      │
+      │  merchant approves the scopes
+      ▼
+GET /shop/authorized/my-app?code=…&state=…&hmac=…&timestamp=…
+      │
+      ├─ check `state` against the app's nonce
+      ├─ verify the query string HMAC with the client secret
+      ├─ ShopifyAPI.App.fetch_token/3 → POST /admin/oauth/access_token
+      ├─ ShopServer.set/2  +  AuthTokenServer.set/2   (persistence fires here)
+      └─ ShopifyAPI.Shop.post_login/1
+      ▼
+302 → https://acme.myshopify.com/admin/apps/<client_id>
+```
+
+Whether the token is a `ShopifyAPI.AuthToken` or a `ShopifyAPI.UserToken`
+depends on the app's access mode; each goes to its own cache. Any failure along
+the way is a bare `404`.
+
+## Multiple apps in one deployment
+
+Nothing here assumes you have only one Shopify app. `ShopifyAPI.AppServer` is
+keyed by app name, so your initializer can return several — a main app and its
+companions, each with its own client id, secret and scopes — and the rest of the
+library follows: tokens are keyed by `{shop, app}`, so one shop can install all
+of them; the router's `:app` path segment picks which app an install runs as;
+and `ShopifyAPI.Plugs.Webhook` needs the app name in its URL because Shopify
+does not include it in the payload.
+
+Give each app an `auth_redirect_uri` ending in its own name and one mounted
+router serves them all:
+
+```elixir
+def init do
+  [
+    %ShopifyAPI.App{
+      name: "my-app",
+      client_id: ...,
+      client_secret: ...,
+      auth_redirect_uri: "https://example.com/shop/authorized/my-app"
+    },
+    %ShopifyAPI.App{
+      name: "my-companion-app",
+      client_id: ...,
+      client_secret: ...,
+      auth_redirect_uri: "https://example.com/shop/authorized/my-companion-app"
+    }
+  ]
+end
+```
+
+A persistence callback can then route each app's tokens wherever it likes by
+matching on `app_name`, since it receives the whole token struct.
+
+## Authenticating requests afterwards
+
+`ShopifyAPI.Plugs.AdminAuthenticator` guards the first load of an embedded app:
+it verifies the request, resolves the shop, app and token, and assigns them to
+the conn. If no token is cached it redirects into the install flow above, which
+is what makes a revoked or never-installed shop recover on its own.
+
+`ShopifyAPI.Plugs.AuthShopSessionToken` guards the requests that follow, where
+the frontend sends a session token as `Authorization: Bearer`. It assigns the
+same things.
+
+Either way your controllers read `conn.assigns.auth_token` and hand it to
+`ShopifyAPI.REST` or `ShopifyAPI.GraphQL`.
+
+## Uninstalling
+
+Shopify revokes the token and sends an `app/uninstalled` webhook. Nothing in
+this library acts on it, so clear both your own storage and the caches —
+`delete/2` and friends do not call the persistence callback, and anything left
+in your database is loaded straight back in on the next restart:
+
+```elixir
+def handle_webhook(_app, shop, "app/uninstalled", _payload) do
+  MyApp.Shops.delete(shop.domain)
+
+  ShopifyAPI.ShopServer.delete(shop.domain)
+  ShopifyAPI.AuthTokenServer.delete(shop.domain, MyApp.app_name())
+  ShopifyAPI.UserTokenServer.delete_for_shop(shop.domain)
+end
+```
+
+Webhooks are handled by `ShopifyAPI.Plugs.Webhook` mounted in your endpoint, not
+by `ShopifyAPI.Router` — it exposes no webhook route.

--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -1,6 +1,25 @@
 defmodule ShopifyAPI.App do
   @moduledoc """
-  ShopifyAPI.App contains logic and a struct for representing a Shopify App.
+  A Shopify app's identity and OAuth credentials.
+
+  Apps are the root of most things in this library: a token belongs to a shop *and* an app, the
+  client secret verifies session tokens and webhook signatures, and the scopes decide what a
+  token may do. `ShopifyAPI.AppServer` caches these structs and is where they are loaded from
+  your own storage.
+
+  ## Fields
+
+    - `:name` — how this library refers to the app; the `app_name` on every token, and the name
+      appended to webhook URLs
+    - `:client_id` — the app's API key, which Shopify sends as the `aud` claim of a session
+      token and which `ShopifyAPI.AppServer.get_by_client_id/1` looks apps up by
+    - `:client_secret` — signs session tokens and webhook HMACs, and authenticates token
+      requests
+    - `:auth_redirect_uri` — where Shopify returns the merchant after they authorize; must match
+      one of the redirect URLs configured in the Partner dashboard
+    - `:nonce` — the `state` value round-tripped through OAuth and checked by
+      `ShopifyAPI.Router`
+    - `:scope` — the comma-separated access scopes requested at install
   """
   @derive {Jason.Encoder,
            only: [:name, :client_id, :client_secret, :auth_redirect_uri, :nonce, :scope]}
@@ -31,9 +50,17 @@ defmodule ShopifyAPI.App do
   alias ShopifyAPI.UserToken
 
   @doc """
-  After an App is installed and the Shop owner ends up back on ourside of the fence we
-  need to request an AuthToken. This function uses ShopifyAPI.AuthRequest.post/3 to
-  fetch and parse the AuthToken.
+  Exchanges an OAuth authorization code for a token struct.
+
+  Called once the merchant has authorized the app and Shopify has redirected back with a
+  `code`. Wraps `ShopifyAPI.AuthRequest.post/3` and parses the response into whichever token
+  Shopify issued: a `ShopifyAPI.UserToken` when the response carries an `associated_user`,
+  otherwise a `ShopifyAPI.AuthToken`. Which one you get is decided by the app's access mode,
+  not by this call.
+
+  Neither the token nor the shop is cached here — `ShopifyAPI.Router` does that with the
+  result. The returned token has no `timestamp`; the router fills it in from the OAuth
+  callback's query parameters.
   """
   @spec fetch_token(__MODULE__.t(), String.t(), String.t()) ::
           UserToken.ok_t() | AuthToken.ok_t() | {:error, String.t()}

--- a/lib/shopify_api/app_server.ex
+++ b/lib/shopify_api/app_server.ex
@@ -1,6 +1,29 @@
 defmodule ShopifyAPI.AppServer do
   @moduledoc """
-  Write-through cache for App structs.
+  Write-through cache for `ShopifyAPI.App` structs, keyed by app name.
+
+  One deployment can serve several Shopify apps, and this cache is what makes that work. Each
+  entry carries its own client id, secret and scopes, so a companion app or a second listing
+  sharing your codebase is just another `ShopifyAPI.App` returned by the initializer. That is
+  also why so much of the library is app-aware: `ShopifyAPI.Router` takes the app name in the
+  path, `ShopifyAPI.AuthTokenServer` keys tokens by `{shop, app}` so one shop can install
+  several of yours, and `ShopifyAPI.Plugs.Webhook` needs the app name appended to its URL
+  because Shopify does not say which app a webhook is for.
+
+  Apps are looked up by name with `get/1`, and by client id with `get_by_client_id/1` — which
+  is how the `aud` claim of a session token is resolved back to the app that issued it.
+
+  Unlike the token caches this one is usually seeded entirely from configuration or your own
+  storage and then left alone; an app's credentials change far less often than its shops do.
+  `ShopifyAPI.AuthTokenServer` documents the caching design and the initializer/persistence
+  contract the four servers share. The differences here are:
+
+    - the cache key is the app's `:name`, and it is also what the persistence callback receives
+      as its first argument
+    - `set/1` and `set/2` always persist. There is no opt-out flag, which means the initializer
+      writes every app it loads straight back out again on boot — keep your persistence
+      callback idempotent
+    - lookups return a bare `:error` rather than an `{:error, reason}` tuple
   """
 
   use GenServer

--- a/lib/shopify_api/auth_request.ex
+++ b/lib/shopify_api/auth_request.ex
@@ -1,7 +1,34 @@
 defmodule ShopifyAPI.AuthRequest do
   @moduledoc """
-  AuthRequest.post/3 contains logic to request AuthTokens from Shopify given an App,
-  Shop domain, and the auth code from the App install.
+  Requests access tokens from a shop's `/admin/oauth/access_token` endpoint.
+
+  Shopify offers two ways to obtain an access token, and this module implements both.
+
+  ## Authorization code grant
+
+  `post/3` trades the `code` query parameter from an OAuth redirect for a token. It is the
+  older flow, driven by `ShopifyAPI.Router`, and it is deliberately thin: it returns the raw
+  `HTTPoison` result and stores nothing. `ShopifyAPI.App.fetch_token/3` is what parses that
+  response into a `ShopifyAPI.AuthToken` or `ShopifyAPI.UserToken`, and the router then writes
+  it to the relevant cache.
+
+  ## Token exchange
+
+  `request_offline_access_token/3` and `request_online_access_token/3` trade a session token
+  for an access token, which is how an embedded app gets one without a redirect. Unlike
+  `post/3` these parse the response *and* write the result to `ShopifyAPI.AuthTokenServer` or
+  `ShopifyAPI.UserTokenServer` themselves. `ShopifyAPI.JWTSessionToken` is the usual caller.
+
+  > #### Only two of the three store what they fetch {: .warning}
+  >
+  > The two exchange functions populate the caches as a side effect; `post/3` does not. Calling
+  > `post/3` and forgetting to store the result leaves the shop authenticated with Shopify but
+  > unknown to this library.
+
+  Shopify's documentation:
+
+    - [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens)
+    - [Token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange)
   """
   require Logger
 
@@ -14,6 +41,13 @@ defmodule ShopifyAPI.AuthRequest do
 
   @headers [{"Content-Type", "application/json"}, {"Accept", "application/json"}]
 
+  @doc """
+  Exchanges an OAuth authorization code for an access token.
+
+  Returns the `HTTPoison` result unchanged — the body is unparsed JSON and nothing is written
+  to any cache. Prefer `ShopifyAPI.App.fetch_token/3`, which wraps this and returns a token
+  struct.
+  """
   @spec post(ShopifyAPI.App.t(), String.t() | list(), String.t()) ::
           {:ok, any()} | {:error, any()}
   def post(app, myshopify_domain, auth_code) when is_struct(app, App) do
@@ -40,9 +74,14 @@ defmodule ShopifyAPI.AuthRequest do
   end
 
   @doc """
+  Exchanges a session token for the shop's offline access token.
+
+  Writes the token to `ShopifyAPI.AuthTokenServer` — and so through your configured persistence
+  callback — before returning it.
+
   Shopify docs:
-    - https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens
-    - https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange
+    - [Session tokens](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens)
+    - [Token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange)
   """
   @spec request_offline_access_token(App.t(), String.t(), String.t()) ::
           {:ok, AuthToken.t()} | {:error, :failed_fetching_offline_token}
@@ -73,9 +112,15 @@ defmodule ShopifyAPI.AuthRequest do
   end
 
   @doc """
+  Exchanges a session token for a staff member's online access token.
+
+  The online counterpart of `request_offline_access_token/3`; writes to
+  `ShopifyAPI.UserTokenServer` before returning. The user the token belongs to is taken from
+  the exchange response, not from the arguments.
+
   Shopify docs:
-    - https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens
-    - https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange
+    - [Session tokens](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens)
+    - [Token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange)
   """
   @spec request_online_access_token(App.t(), String.t(), String.t()) ::
           {:ok, UserToken.t()} | {:error, :failed_fetching_online_token}

--- a/lib/shopify_api/auth_token.ex
+++ b/lib/shopify_api/auth_token.ex
@@ -1,4 +1,19 @@
 defmodule ShopifyAPI.AuthToken do
+  @moduledoc """
+  An offline access token, authorizing an app to act on a shop's behalf.
+
+  Offline tokens belong to the app rather than to a user, which makes them what REST and
+  GraphQL calls authenticate with. They are obtained during installation and cached by
+  `ShopifyAPI.AuthTokenServer`, which is also where the storage callbacks that outlive a
+  restart are configured.
+
+  This struct models a *non-expiring* offline token, so it carries no expiry or refresh
+  token.
+
+  The online, per-user counterpart is `ShopifyAPI.UserToken`. Shopify covers both in
+  [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens).
+  """
+
   @derive {Jason.Encoder, only: [:code, :app_name, :shop_name, :token, :timestamp, :plus]}
   defstruct code: "",
             app_name: "",
@@ -18,7 +33,7 @@ defmodule ShopifyAPI.AuthToken do
           app_name: String.t(),
           shop_name: String.t(),
           token: String.t(),
-          timestamp: 0,
+          timestamp: integer(),
           plus: boolean()
         }
   @type ok_t :: {:ok, t()}

--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -1,6 +1,156 @@
 defmodule ShopifyAPI.AuthTokenServer do
   @moduledoc """
-  Write-through cache for AuthToken structs.
+  Write-through cache for `ShopifyAPI.AuthToken` structs.
+
+  An offline auth token is written here once, when a shop installs the app, and is read on
+  every authenticated request afterwards. This cache sits in front of whatever storage your
+  application uses: configure an `:initializer` to load tokens back at boot and a
+  `:persistence` callback to write them out. Without them the cache is purely in-memory and
+  every token is lost when the application stops.
+
+  ## Storage model
+
+  Tokens are held in a public, named ETS table keyed by `{shop_name, app_name}`. Because the
+  table is public, every function in this module runs in the calling process — the
+  `GenServer` implements no `handle_call/3` or `handle_cast/2` and is never a bottleneck. It
+  exists to own the table and to run the initializer once from `c:GenServer.init/1`.
+
+  The table belongs to that process, so it is destroyed if the server crashes.
+  `ShopifyAPI.Supervisor` starts a replacement and the initializer repopulates it; anything
+  written with `set/2` but never persisted is gone.
+
+  ## Offline and online tokens
+
+  A `ShopifyAPI.AuthToken` is an *offline* token: it belongs to the app rather than to a user,
+  and is what REST and GraphQL calls authenticate with. Per-user *online* tokens are
+  `ShopifyAPI.UserToken` structs, cached separately by `ShopifyAPI.UserTokenServer`, and those
+  expire and are validated when read. `ShopifyAPI.App.fetch_token/3` decides which of the two
+  an OAuth response produces.
+
+  This cache models Shopify's *non-expiring* offline tokens: the struct carries no expiry and
+  nothing here evicts or refreshes. Shopify also issues expiring offline tokens, which come
+  with a refresh token; those are not supported yet.
+
+  Shopify documents the distinction under
+  [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens).
+
+  ## Configuration
+
+      config :shopify_api, ShopifyAPI.AuthTokenServer,
+        initializer: {MyApp.AuthToken, :init, []},
+        persistence: {MyApp.AuthToken, :save, []}
+
+  Both keys are optional. Configuration is read on each call rather than cached, so omitting
+  the block entirely — or setting either key to `nil` — disables that half of the behaviour.
+
+  ## Initializer
+
+  The initializer runs once during startup, invoked as `apply(module, function, args)`. The
+  configured arguments are passed through exactly as given; nothing is prepended. A
+  `{module, function}` tuple is also accepted and is called with no arguments.
+
+  It must return an enumerable of `ShopifyAPI.AuthToken` structs. Anything in that enumerable
+  which is not a `ShopifyAPI.AuthToken` struct is silently discarded. Tokens loaded this way
+  are not written back out through the persistence callback.
+
+  It runs synchronously inside `c:GenServer.init/1`, so the supervisor blocks until it
+  returns. List `ShopifyAPI.Supervisor` after anything the initializer depends on, such as
+  your `Ecto.Repo`.
+
+  ## Persistence
+
+  The persistence callback is invoked by `set/2` as
+  `apply(module, function, [key, token | args])` — the cache key first, the token second, and
+  any configured arguments appended. Its return value is ignored.
+
+  The `key` is the string built by `ShopifyAPI.AuthToken.create_key/1`,
+  `"shop_name:app_name"`, and not the `{shop_name, app_name}` tuple the table is keyed by.
+  Implementations typically ignore it and read `shop_name` and `app_name` off the token.
+
+  The callback runs synchronously, in the calling process — which during installation is
+  Shopify's OAuth redirect.
+
+  > #### Persistence failures reach the caller {: .warning}
+  >
+  > Exceptions raised by the callback are not rescued; they propagate out of `set/2`. Raising
+  > while a shop is installing fails the OAuth callback and leaves the install incomplete.
+  > Log the failure and return instead.
+
+  > #### Deletes are never persisted {: .warning}
+  >
+  > `delete/2` and `drop_all/0` only clear the cache. Neither calls the persistence callback,
+  > so a token left in your own storage is loaded straight back in by the initializer on the
+  > next restart. Delete it from both.
+
+  ### Example
+
+  A persistence module backed by Ecto:
+
+      defmodule MyApp.AuthToken do
+        require Logger
+
+        alias ShopifyAPI.AuthToken
+
+        def init do
+          Enum.map(MyApp.Repo.all(MyApp.Schema.AuthToken), fn row ->
+            %AuthToken{
+              shop_name: row.shop_name,
+              app_name: row.app_name,
+              token: row.token,
+              plus: row.plus
+            }
+          end)
+        end
+
+        def save(_key, %AuthToken{} = token) do
+          %MyApp.Schema.AuthToken{}
+          |> MyApp.Schema.AuthToken.changeset(Map.from_struct(token))
+          |> MyApp.Repo.insert(
+            on_conflict: {:replace, [:token, :plus]},
+            conflict_target: [:shop_name, :app_name]
+          )
+          |> case do
+            {:ok, _} ->
+              :ok
+
+            {:error, changeset} ->
+              Logger.error("Could not persist auth token: \#{inspect(changeset)}")
+          end
+        end
+      end
+
+  `Map.from_struct/1` is enough here because the schema's field names match the struct's;
+  `Ecto.Changeset.cast/4` discards the rest. Conflicting on `[:shop_name, :app_name]` rather
+  than on `:shop_name` alone keeps a shop able to install more than one of your apps.
+
+  A callback does not have to persist everything it is handed. Matching on `app_name` routes
+  several apps' tokens to different storage:
+
+      def save(_key, %AuthToken{app_name: "my-companion-app"} = token), do: store_companion(token)
+      def save(_key, token), do: Logger.info("Not persisting a token for \#{token.app_name}")
+
+  ## Handling app uninstalls
+
+  Nothing in this library deletes tokens. Shopify revokes a token when a shop uninstalls the
+  app and notifies you through the
+  [`app/uninstalled` webhook](https://shopify.dev/docs/api/webhooks), so subscribe to it and
+  clear both your storage and this cache, or a reinstall will reuse a dead token:
+
+      def handle_webhook(_app, shop, "app/uninstalled", _payload) do
+        MyApp.AuthTokens.delete(shop.domain, MyApp.app_name())
+        ShopifyAPI.AuthTokenServer.delete(shop.domain, MyApp.app_name())
+      end
+
+  ## Testing
+
+  Pass `false` as the second argument to `set/2` to fill the cache without invoking the
+  persistence callback:
+
+      ShopifyAPI.AuthTokenServer.set(%ShopifyAPI.AuthToken{shop_name: shop, app_name: app}, false)
+
+  Or turn both callbacks off for the test environment:
+
+      config :shopify_api, ShopifyAPI.AuthTokenServer, initializer: nil, persistence: nil
   """
 
   use GenServer
@@ -10,11 +160,43 @@ defmodule ShopifyAPI.AuthTokenServer do
 
   @table __MODULE__
 
+  @doc """
+  Returns every cached token, keyed by `{shop_name, app_name}`.
+
+  The keys are the tuples the table is keyed by, not the `"shop_name:app_name"` strings that
+  `ShopifyAPI.AuthToken.create_key/1` builds:
+
+      %{{"shop.myshopify.com", "my-app"} => %ShopifyAPI.AuthToken{}}
+
+  Intended for introspection and debugging. Prefer `get/2`, `get_for_shop/1` or
+  `get_for_app/1` in application code.
+  """
+  @spec all() :: %{optional({String.t(), String.t()}) => AuthToken.t()}
   def all, do: @table |> :ets.tab2list() |> Map.new()
 
+  @doc """
+  Returns the number of tokens currently cached.
+  """
   @spec count() :: integer()
   def count, do: :ets.info(@table, :size)
 
+  @doc """
+  Stores a token in the cache and, by default, persists it.
+
+  Pass `false` as the second argument to update the cache alone, leaving the persistence
+  callback uncalled. That is what the initializer does with the tokens it loads, since they
+  came out of storage to begin with, and it is usually what you want in tests.
+
+  Note that the default differs from `ShopifyAPI.ShopServer.set/2`, which does not persist
+  unless asked to.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "shop.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token, false)
+      :ok
+
+  """
   @spec set(AuthToken.t()) :: :ok
   @spec set(AuthToken.t(), boolean()) :: :ok
   def set(token, should_persist \\ true) when is_struct(token, AuthToken) do
@@ -23,6 +205,23 @@ defmodule ShopifyAPI.AuthTokenServer do
     :ok
   end
 
+  @doc """
+  Fetches the token a shop issued for an app.
+
+  When no token is cached the error term carries a human-readable string rather than an atom.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "shop.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token)
+      iex> ShopifyAPI.AuthTokenServer.get("shop.myshopify.com", "my-app")
+      {:ok, token}
+
+      # Assuming nothing has been stored for the shop
+      iex> ShopifyAPI.AuthTokenServer.get("unknown.myshopify.com", "my-app")
+      {:error, "Auth token for unknown.myshopify.com:my-app could not be found."}
+
+  """
   @spec get(String.t(), String.t()) :: {:ok, AuthToken.t()} | {:error, String.t()}
   def get(shop, app) when is_binary(shop) and is_binary(app) do
     case :ets.lookup(@table, {shop, app}) do
@@ -31,22 +230,78 @@ defmodule ShopifyAPI.AuthTokenServer do
     end
   end
 
+  @doc """
+  Returns every cached token belonging to a shop, across all apps.
+
+  The result is a bare list rather than an ok tuple, and is empty when the shop has no cached
+  tokens.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "one-app.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token)
+      iex> ShopifyAPI.AuthTokenServer.get_for_shop("one-app.myshopify.com")
+      [token]
+
+      iex> ShopifyAPI.AuthTokenServer.get_for_shop("unknown.myshopify.com")
+      []
+
+  """
+  @spec get_for_shop(String.t()) :: [AuthToken.t()]
   def get_for_shop(shop) when is_binary(shop) do
     match_spec = [{{{shop, :_}, :"$1"}, [], [:"$1"]}]
     :ets.select(@table, match_spec)
   end
 
+  @doc """
+  Returns every cached token issued for an app, across all shops.
+
+  Like `get_for_shop/1`, the result is a bare list and is empty when nothing matches.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "shop.myshopify.com", app_name: "my-report-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token)
+      iex> ShopifyAPI.AuthTokenServer.get_for_app("my-report-app")
+      [token]
+
+  """
+  @spec get_for_app(String.t()) :: [AuthToken.t()]
   def get_for_app(app) when is_binary(app) do
     match_spec = [{{{:_, app}, :"$1"}, [], [:"$1"]}]
     :ets.select(@table, match_spec)
   end
 
+  @doc """
+  Removes a shop's token for an app from the cache.
+
+  Only the cache is touched — the persistence callback is not called. A token still sitting in
+  your own storage is loaded back in by the initializer on the next restart, so delete it
+  there too. See the module documentation on handling app uninstalls.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "closing.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token)
+      iex> ShopifyAPI.AuthTokenServer.delete("closing.myshopify.com", "my-app")
+      :ok
+      iex> ShopifyAPI.AuthTokenServer.get_for_shop("closing.myshopify.com")
+      []
+
+  """
   @spec delete(String.t(), String.t()) :: :ok
   def delete(shop_name, app) do
     :ets.delete(@table, {shop_name, app})
     :ok
   end
 
+  @doc """
+  Removes every token from the cache.
+
+  As with `delete/2`, persisted tokens are left alone, so the initializer repopulates the
+  cache on the next restart.
+  """
+  @spec drop_all() :: true
   def drop_all, do: :ets.delete_all_objects(@table)
 
   ## GenServer Callbacks
@@ -56,7 +311,7 @@ defmodule ShopifyAPI.AuthTokenServer do
   @impl GenServer
   def init(:ok) do
     create_table!()
-    for %AuthToken{} = shop <- do_initialize(), do: set(shop, false)
+    for %AuthToken{} = token <- do_initialize(), do: set(token, false)
     {:ok, :no_state}
   end
 

--- a/lib/shopify_api/jwt_session_token.ex
+++ b/lib/shopify_api/jwt_session_token.ex
@@ -1,11 +1,47 @@
 defmodule ShopifyAPI.JWTSessionToken do
-  @doc """
-  Handles validation, data fetching, and exchange for Shopify Session Tokens.
+  @moduledoc """
+  Validates Shopify session tokens and exchanges them for access tokens.
 
-  [Shopify documentation](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens)
+  An embedded app is handed a
+  [session token](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens)
+  on every request from App Bridge, normally as an `Authorization: Bearer` header. It is a
+  short-lived JWT signed with the app's client secret that identifies the shop and the staff
+  member, but grants no API access of its own.
+
+  `get_offline_token/2` and `get_user_token/2` turn one into an access token that does. Both
+  read from the relevant cache first and fall back to
+  [token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange)
+  when there is nothing usable there, so an embedded app can obtain its tokens without ever
+  sending a merchant through the OAuth redirect that `ShopifyAPI.Router` implements.
+
+  ## Reading a session token
+
+  `verify/2` checks the signature; the remaining readers pull claims out of the decoded JWT:
+  `app/1` resolves the `aud` claim to a `ShopifyAPI.App`, `myshopify_domain/1` the `dest`
+  claim, and `user_id/1` the `sub` claim.
+
+  ## Exchanging a session token
+
+  `get_offline_token/2` looks in `ShopifyAPI.AuthTokenServer` and exchanges on a miss.
+  `get_user_token/2` looks in `ShopifyAPI.UserTokenServer` with `get_valid/3`, so it also
+  exchanges when the cached token has expired. Both store what they receive, and neither
+  refreshes a token in place.
+
+  > #### The post-login hook runs unsupervised {: .warning}
+  >
+  > After a successful exchange these functions fire the `ShopifyAPI.Shop` `post_login` hook
+  > inside a `Task.async/1` that is never awaited. The task is linked to the calling process, so
+  > an exception in your hook takes down the request that triggered it, and its reply is left
+  > sitting in that process's mailbox. Keep the hook total, or hand its work to a job queue.
   """
   require Logger
 
+  @doc """
+  Verifies a session token's signature against an app's client secret.
+
+  Returns JOSE's three-element result rather than an ok tuple, so match on `{true, jwt, _jws}`
+  to accept a token and treat everything else as a rejection.
+  """
   @spec verify(String.t(), String.t()) ::
           {valid? :: boolean(), jwt :: JOSE.JWT.t(), jws :: JOSE.JWS.t()}
   def verify(token, client_secret) do
@@ -13,6 +49,15 @@ defmodule ShopifyAPI.JWTSessionToken do
     JOSE.JWT.verify_strict(jwk, ["HS256"], token)
   end
 
+  @doc """
+  Resolves a session token's `aud` claim to the `ShopifyAPI.App` it was issued for.
+
+  > #### A raw token is read unverified {: .warning}
+  >
+  > Given a binary this peeks at the JWT payload without checking its signature, because the
+  > app it names is what supplies the secret needed to check it. Treat the result as untrusted
+  > until `verify/2` has passed.
+  """
   @spec app(JOSE.JWT.t() | String.t()) :: {:ok, ShopifyAPI.App.t()} | {:error, any()}
   def app(%JOSE.JWT{fields: %{"aud" => client_id}}) do
     case ShopifyAPI.AppServer.get_by_client_id(client_id) do
@@ -23,6 +68,9 @@ defmodule ShopifyAPI.JWTSessionToken do
 
   def app(token) when is_binary(token), do: token |> JOSE.JWT.peek_payload() |> app()
 
+  @doc """
+  Returns the myshopify domain a session token was issued for, from its `dest` claim.
+  """
   @spec myshopify_domain(JOSE.JWT.t()) :: {:ok, String.t()} | {:error, any()}
   def myshopify_domain(%JOSE.JWT{fields: %{"dest" => shop_url}}) do
     shop_url
@@ -36,6 +84,11 @@ defmodule ShopifyAPI.JWTSessionToken do
 
   def myshopify_domain(_), do: {:error, "Invalid user token or shop name not found"}
 
+  @doc """
+  Returns the id of the staff member a session token was issued for, from its `sub` claim.
+
+  This is the `associated_user_id` that `ShopifyAPI.UserTokenServer` keys online tokens by.
+  """
   @spec user_id(JOSE.JWT.t()) :: {:ok, integer()} | {:error, any()}
   def user_id(%JOSE.JWT{fields: %{"sub" => user_id}}),
     do: {:ok, String.to_integer(user_id)}
@@ -43,10 +96,21 @@ defmodule ShopifyAPI.JWTSessionToken do
   def user_id(_),
     do: {:error, "Invalid user token or no id"}
 
+  @doc """
+  Returns the shop's offline token, exchanging the session token for one if the cache has none.
+
+  Takes the decoded JWT and the raw token string it came from: the first names the shop and
+  app, the second is what Shopify wants as the subject of an exchange. A freshly exchanged
+  token is written to `ShopifyAPI.AuthTokenServer` by
+  `ShopifyAPI.AuthRequest.request_offline_access_token/3` before it is returned, and the
+  `post_login` hook fires.
+
+  This is the token-exchange equivalent of installing through `ShopifyAPI.Router`.
+  """
   @spec get_offline_token(JOSE.JWT.t(), String.t()) ::
           {:ok, ShopifyAPI.AuthToken.t()}
           | {:error, :invalid_session_token}
-          | {:error, :failed_fetching_online_token}
+          | {:error, :failed_fetching_offline_token}
   def get_offline_token(%JOSE.JWT{} = jwt, token) do
     with {:ok, myshopify_domain} <- myshopify_domain(jwt),
          {:ok, app} <- app(jwt) do
@@ -73,6 +137,13 @@ defmodule ShopifyAPI.JWTSessionToken do
     end
   end
 
+  @doc """
+  Returns the staff member's online token, exchanging the session token for one if needed.
+
+  The online counterpart of `get_offline_token/2`. Because it reads through
+  `ShopifyAPI.UserTokenServer.get_valid/3`, it exchanges for a new token when the cached one
+  has expired as well as when there is none — which is how an expiring token is renewed here.
+  """
   @spec get_user_token(JOSE.JWT.t(), String.t()) ::
           {:ok, ShopifyAPI.UserToken.t()}
           | {:error, :invalid_session_token}

--- a/lib/shopify_api/router.ex
+++ b/lib/shopify_api/router.ex
@@ -1,4 +1,61 @@
 defmodule ShopifyAPI.Router do
+  @moduledoc """
+  A `Plug.Router` implementing Shopify's OAuth install flow.
+
+  Forward a scope to it from your own router and merchants can install the app through it:
+
+      scope "/shop" do
+        forward("/", ShopifyAPI.Router)
+      end
+
+  An embedded app does not have to use this. `ShopifyAPI.JWTSessionToken.get_offline_token/2`
+  obtains the same offline token by exchanging a session token, with no redirects.
+
+  ## Routes
+
+    - `GET /install/:app` and `GET /install` — redirect the merchant to Shopify's authorization
+      screen. Name the app either in the path, `/install/my-app`, or in an `app` query
+      parameter, `/install?app=my-app`.
+    - `GET /authorized/:app` — the callback Shopify redirects back to. With no `code` parameter
+      it starts the install instead, which is what makes an install link from the Partner
+      dashboard work.
+
+  Both the shop domain and the app name may arrive more than one way. The domain is taken from
+  the `x-shopify-shop-domain` header, falling back to a `shop` parameter. The app name is taken
+  from an `app` parameter, which may be the `:app` path segment or a query string value; with
+  neither it falls back to the last segment of the request path, which for a bare
+  `GET /install` is `"install"` and will not match an app.
+
+  The `:app` segment is how one deployment installs more than one Shopify app — it selects
+  which `ShopifyAPI.App`, and so which client id and secret, the flow runs with. Give each app
+  an `auth_redirect_uri` ending in its own name (`https://example.com/shop/authorized/my-app`)
+  and a single mounted router serves them all. See `ShopifyAPI.AppServer`.
+
+  ## What the callback does
+
+  On `GET /authorized/:app`, in order: look up the `ShopifyAPI.App`, check the `state`
+  parameter against the app's nonce, verify the query string HMAC, exchange the `code` for a
+  token with `ShopifyAPI.App.fetch_token/3`, then cache the shop and the token and fire the
+  `ShopifyAPI.Shop` `post_login` hook. The merchant is finally redirected to the app inside
+  their admin. Any failure along the way is a bare `404`.
+
+  Whether that token is a `ShopifyAPI.AuthToken` or a `ShopifyAPI.UserToken` depends on the
+  app's access mode; each is written to its own cache.
+
+  > #### The nonce check is skipped when absent {: .warning}
+  >
+  > Shopify omits `state` for installs started from the Partner dashboard, so a request with no
+  > `state` parameter passes the nonce check rather than failing it. The HMAC check still
+  > applies to every request.
+
+  ## Webhooks are elsewhere
+
+  This router handles installation only — it exposes no webhook route. Incoming webhooks are
+  handled by `ShopifyAPI.Plugs.Webhook`, which mounts in your endpoint at its own `:prefix`,
+  and the `ShopifyAPI.Webhook` `:uri` config must match that prefix rather than the scope this
+  router is forwarded from.
+  """
+
   use Plug.Router
   require Logger
 
@@ -125,12 +182,26 @@ defmodule ShopifyAPI.Router do
     |> List.first()
   end
 
+  @doc """
+  Returns the myshopify domain a request is about.
+
+  Shopify identifies the shop with an `x-shopify-shop-domain` header on some requests and a
+  `shop` query parameter on others, so both are checked, header first. Returns `nil` when
+  neither is present.
+  """
+  @spec shop_domain(Plug.Conn.t()) :: String.t() | nil
   def shop_domain(conn), do: shop_domain_from_header(conn) || conn.params["shop"]
 
   @doc false
   defp app_name(conn), do: conn.params["app"] || List.last(conn.path_info)
 
-  @doc false
+  @doc """
+  Checks a request's query parameters against the `hmac` parameter Shopify signed them with.
+
+  Every parameter except `hmac` and `signature` is sorted, joined into a query string and
+  hashed with the app's client secret. Returns `false` on any mismatch, including a request
+  carrying no `hmac` at all.
+  """
   @spec verify_params_with_hmac(ShopifyAPI.App.t(), map()) :: boolean()
   def verify_params_with_hmac(%ShopifyAPI.App{client_secret: secret}, params) do
     params["hmac"] ==

--- a/lib/shopify_api/security.ex
+++ b/lib/shopify_api/security.ex
@@ -1,4 +1,26 @@
 defmodule ShopifyAPI.Security do
+  @moduledoc """
+  SHA-256 HMACs in the two encodings Shopify uses to sign requests.
+
+  Shopify picks the encoding by context, so both exist here: hex for the `hmac` query parameter
+  on OAuth callbacks and app proxy requests, Base64 for the `X-Shopify-Hmac-Sha256` header on
+  webhooks. `ShopifyAPI.Router` and `ShopifyAPI.Plugs.Webhook` verify incoming requests with
+  these; an app rarely calls them directly.
+
+  Both return the digest as a string. Compare digests with `Plug.Crypto.secure_compare/2`
+  rather than `==` to avoid leaking timing information.
+  """
+
+  @doc """
+  Returns the lowercase hex-encoded SHA-256 HMAC of `text` under `secret`.
+
+  ## Examples
+
+      iex> ShopifyAPI.Security.base16_sha256_hmac("shop=acme.myshopify.com", "hush")
+      "06e3aa393cc9fcfb6b0bea6977dc046acbc956d8bc5bb877ee9691af2e2dbdd9"
+
+  """
+  @spec base16_sha256_hmac(iodata(), binary()) :: String.t()
   def base16_sha256_hmac(text, secret) do
     :sha256
     |> hmac(secret, text)
@@ -6,6 +28,16 @@ defmodule ShopifyAPI.Security do
     |> String.downcase()
   end
 
+  @doc """
+  Returns the Base64-encoded SHA-256 HMAC of `text` under `secret`.
+
+  ## Examples
+
+      iex> ShopifyAPI.Security.base64_sha256_hmac("shop=acme.myshopify.com", "hush")
+      "BuOqOTzJ/PtrC+ppd9wEasvJVti8W7h37paRry4tvdk="
+
+  """
+  @spec base64_sha256_hmac(iodata(), binary()) :: String.t()
   def base64_sha256_hmac(text, secret) do
     :sha256
     |> hmac(secret, text)

--- a/lib/shopify_api/shop.ex
+++ b/lib/shopify_api/shop.ex
@@ -1,4 +1,32 @@
 defmodule ShopifyAPI.Shop do
+  @moduledoc """
+  A Shopify shop, identified by its myshopify domain.
+
+  The struct itself is barely more than that domain — the interesting parts of this module are
+  the `post_login` hook and the helpers for moving between a shop's slug, domain and URI.
+  `ShopifyAPI.ShopServer` caches these structs.
+
+  ## The post_login hook
+
+  Configure an MFA tuple to be told whenever a shop finishes authenticating:
+
+      config :shopify_api, ShopifyAPI.Shop, post_login: {MyApp.Shop, :post_login, []}
+
+  `post_login/1` is called with the token that was just issued — a `ShopifyAPI.AuthToken` or a
+  `ShopifyAPI.UserToken` — after an install through `ShopifyAPI.Router` or a token exchange
+  through `ShopifyAPI.JWTSessionToken`. It is the place to register webhooks, backfill data, or
+  mark a shop active.
+
+  > #### The hook must be a three-element tuple, and its arguments are dropped {: .warning}
+  >
+  > The configured MFA is invoked as `apply(module, function, [token])`. A `{module, function}`
+  > pair raises, and any arguments in the third element are discarded rather than appended —
+  > unlike the cache servers' callbacks, which do append them.
+
+  A deprecated `:post_install` key is still read *in addition to* `:post_login`, and only for
+  offline tokens. Configuring both calls your hook twice.
+  """
+
   @derive {Jason.Encoder, only: [:domain]}
   defstruct domain: ""
 
@@ -11,6 +39,12 @@ defmodule ShopifyAPI.Shop do
 
   @shopify_domain "myshopify.com"
 
+  @doc """
+  Invokes the configured `post_login` hook with a freshly issued token.
+
+  Returns whatever the hook returns, or `nil` when none is configured. For a
+  `ShopifyAPI.AuthToken` the deprecated `:post_install` hook is invoked afterwards as well.
+  """
   @spec post_login(ShopifyAPI.AuthToken.t() | ShopifyAPI.UserToken.t()) :: any()
   def post_login(%ShopifyAPI.AuthToken{} = token) do
     :post_login |> shop_config() |> call_post_login(token)
@@ -22,12 +56,36 @@ defmodule ShopifyAPI.Shop do
     :post_login |> shop_config() |> call_post_login(token)
   end
 
+  @doc """
+  Expands a shop's slug into its full myshopify domain.
+
+  ## Examples
+
+      iex> ShopifyAPI.Shop.domain_from_slug("acme")
+      "acme.myshopify.com"
+
+  """
   @spec domain_from_slug(String.t()) :: String.t()
   def domain_from_slug(slug), do: "#{slug}.#{@shopify_domain}"
 
+  @doc """
+  Reduces a myshopify domain to its slug.
+
+  ## Examples
+
+      iex> ShopifyAPI.Shop.slug_from_domain("acme.myshopify.com")
+      "acme"
+
+  """
   @spec slug_from_domain(String.t()) :: String.t()
   def slug_from_domain(domain), do: String.replace(domain, "." <> @shopify_domain, "")
 
+  @doc """
+  Builds the base `URI` for a shop, from either the struct or its domain.
+
+  In `:dev` and `:test` the domain may carry a port (`"localhost:4040"`), so that requests can
+  be pointed at a Bypass server instead of Shopify.
+  """
   @spec to_uri(String.t()) :: URI.t()
   @spec to_uri(t()) :: URI.t()
   def to_uri(%_{domain: domain} = shop) when is_struct(shop, __MODULE__), do: to_uri(domain)

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -1,6 +1,17 @@
 defmodule ShopifyAPI.ShopServer do
   @moduledoc """
-  Write-through cache for Shop structs.
+  Write-through cache for `ShopifyAPI.Shop` structs, keyed by myshopify domain.
+
+  `ShopifyAPI.AuthTokenServer` documents the caching design and the initializer/persistence
+  contract the four servers share. What differs here:
+
+    - `set/2` does **not** persist unless you ask it to, the opposite of the token caches. The
+      struct holds only a domain, so there is usually nothing worth writing out
+    - `get_or_create/2` returns a shop for any domain, caching a new struct on a miss — and it
+      *does* persist by default
+    - `get/1` returns a bare `:error` rather than an `{:error, reason}` tuple
+
+  `ShopifyAPI.Router` populates this during install, and `delete/1` clears a shop on uninstall.
   """
 
   use GenServer

--- a/lib/shopify_api/user_token_server.ex
+++ b/lib/shopify_api/user_token_server.ex
@@ -1,6 +1,60 @@
 defmodule ShopifyAPI.UserTokenServer do
   @moduledoc """
-  Write-through cache for UserToken structs.
+  Write-through cache for `ShopifyAPI.UserToken` structs.
+
+  Online tokens are issued per staff member rather than per app, and they expire. One is
+  obtained when a user opens the embedded app and is used for requests that must respect that
+  user's own permissions. `ShopifyAPI.AuthTokenServer` is the offline counterpart, and
+  documents the caching design and the initializer/persistence contract that both servers
+  share — only the differences are described here.
+
+  Shopify covers the distinction under
+  [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens).
+
+  ## Storage model
+
+  Identical to `ShopifyAPI.AuthTokenServer` — a public, named ETS table owned by a `GenServer`
+  that does nothing but hold it and run the initializer — except that entries are keyed by
+  `{shop_name, app_name, associated_user_id}`. One shop has as many tokens as it has staff
+  members using the app.
+
+  ## Expiry
+
+  Unlike an offline token, a user token goes stale. `get/3` returns whatever is cached without
+  regard to that; `get_valid/3` pipes the result through `validate/1`, which treats a token as
+  live while `timestamp + expires_in` has not yet passed:
+
+      user_token.timestamp + user_token.expires_in >= DateTime.to_unix(DateTime.utc_now())
+
+  The comparison is exact — there is no grace period for clock skew between this node and
+  Shopify, and nothing renews a token in place. An expired entry stays in the cache until it is
+  overwritten by a fresh one or removed with `delete/1`.
+
+  > #### Expired and missing are the same error {: .warning}
+  >
+  > `validate/1` maps *both* an expired token and a cache miss to
+  > `{:error, :invalid_user_token}`, so `get_valid/3` cannot tell them apart. Call `get/3` when
+  > you need to distinguish them — it returns `{:error, :user_token_not_found}` for a miss.
+
+  ## Configuration
+
+      config :shopify_api, ShopifyAPI.UserTokenServer,
+        initializer: {MyApp.UserToken, :init, []},
+        persistence: {MyApp.UserToken, :save, []}
+
+  The callbacks behave exactly as `ShopifyAPI.AuthTokenServer`'s do, including that the
+  persistence key is a string — here `"shop_name:app_name:associated_user_id"` from
+  `ShopifyAPI.UserToken.create_key/1` — rather than the tuple the table is keyed by.
+
+  Configuring them is optional in a way it is not for offline tokens. A user token is worth
+  little beyond the session that produced it, so an app can leave both unset and let the cache
+  refill through OAuth, accepting that every restart sends active users back through it.
+
+  ## Removing tokens
+
+  `delete/1` takes a token struct rather than its parts, and `delete_for_shop/1` clears every
+  user's token for a shop, which is what an `app/uninstalled` webhook wants. As with the offline
+  cache, neither calls the persistence callback — delete from your own storage too.
   """
 
   use GenServer
@@ -13,15 +67,37 @@ defmodule ShopifyAPI.UserTokenServer do
   @type ok_t :: {:ok, t()}
   @type error_not_found :: {:error, :user_token_not_found}
 
+  @doc """
+  Returns every cached token, keyed by `{shop_name, app_name, associated_user_id}`.
+
+  Intended for introspection. Prefer `get/3` or `get_valid/3` in application code.
+  """
+  @spec all() :: %{optional({String.t(), String.t(), integer()}) => t()}
   def all do
     @table
     |> :ets.tab2list()
     |> Map.new()
   end
 
+  @doc """
+  Returns the number of tokens currently cached, expired ones included.
+  """
   @spec count() :: integer()
   def count, do: :ets.info(@table, :size)
 
+  @doc """
+  Stores a token in the cache and, by default, persists it.
+
+  Pass `false` as the second argument to skip the persistence callback, as the initializer does
+  for tokens it has just loaded out of storage.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{shop_name: "shop.myshopify.com", app_name: "my-app", associated_user_id: 1}
+      iex> ShopifyAPI.UserTokenServer.set(token, false)
+      :ok
+
+  """
   @spec set(UserToken.t()) :: :ok
   @spec set(UserToken.t(), boolean()) :: :ok
   def set(token, should_persist \\ true) when is_struct(token, UserToken) do
@@ -30,6 +106,23 @@ defmodule ShopifyAPI.UserTokenServer do
     :ok
   end
 
+  @doc """
+  Fetches a user's token for a shop and app, without checking whether it has expired.
+
+  Use this when a cache miss and an expired token need different handling — `get_valid/3`
+  reports both as `{:error, :invalid_user_token}`.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{shop_name: "shop.myshopify.com", app_name: "my-app", associated_user_id: 2}
+      iex> ShopifyAPI.UserTokenServer.set(token)
+      iex> ShopifyAPI.UserTokenServer.get("shop.myshopify.com", "my-app", 2)
+      {:ok, token}
+
+      iex> ShopifyAPI.UserTokenServer.get("unknown.myshopify.com", "my-app", 1)
+      {:error, :user_token_not_found}
+
+  """
   @spec get(String.t(), String.t(), integer()) :: ok_t() | error_not_found()
   def get(myshopify_domain, app_name, user_id)
       when is_binary(myshopify_domain) and is_binary(app_name) and is_number(user_id) do
@@ -39,10 +132,59 @@ defmodule ShopifyAPI.UserTokenServer do
     end
   end
 
+  @doc """
+  Fetches a user's token for a shop and app, provided it has not expired.
+
+  Returns `{:error, :invalid_user_token}` both when the token has expired and when there is no
+  token cached at all. Reach for `get/3` if you need to tell those apart — for instance to
+  decide between refreshing and sending the user back through OAuth.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{
+      ...>   shop_name: "shop.myshopify.com",
+      ...>   app_name: "my-app",
+      ...>   associated_user_id: 3,
+      ...>   timestamp: DateTime.to_unix(DateTime.utc_now()),
+      ...>   expires_in: 86_400
+      ...> }
+      iex> ShopifyAPI.UserTokenServer.set(token)
+      iex> ShopifyAPI.UserTokenServer.get_valid("shop.myshopify.com", "my-app", 3)
+      {:ok, token}
+
+      # An hour-long token issued in 2020
+      iex> expired = %ShopifyAPI.UserToken{
+      ...>   shop_name: "shop.myshopify.com",
+      ...>   app_name: "my-app",
+      ...>   associated_user_id: 4,
+      ...>   timestamp: 1_600_000_000,
+      ...>   expires_in: 3600
+      ...> }
+      iex> ShopifyAPI.UserTokenServer.set(expired)
+      iex> ShopifyAPI.UserTokenServer.get_valid("shop.myshopify.com", "my-app", 4)
+      {:error, :invalid_user_token}
+
+  """
   @spec get_valid(String.t(), String.t(), integer()) :: ok_t() | {:error, :invalid_user_token}
   def get_valid(myshopify_domain, app_name, user_id),
     do: myshopify_domain |> get(app_name, user_id) |> validate()
 
+  @doc """
+  Checks the expiry on a `get/3` result, for piping.
+
+  Takes the result tuple rather than a token, so it composes directly onto `get/3` — which is
+  all `get_valid/3` does. A token counts as live while `timestamp + expires_in` is still in the
+  future; the comparison allows no margin for clock skew.
+
+  Every input other than a live `{:ok, token}` collapses to `{:error, :invalid_user_token}`,
+  including `{:error, :user_token_not_found}`.
+
+  ## Examples
+
+      iex> ShopifyAPI.UserTokenServer.validate({:error, :user_token_not_found})
+      {:error, :invalid_user_token}
+
+  """
   @spec validate(ok_t() | error_not_found()) :: ok_t() | {:error, :invalid_user_token}
   def validate({:ok, user_token}) do
     now = DateTime.to_unix(DateTime.utc_now())
@@ -56,28 +198,105 @@ defmodule ShopifyAPI.UserTokenServer do
 
   def validate(_), do: {:error, :invalid_user_token}
 
+  @doc """
+  Returns every cached token for a shop, one per staff member, expired ones included.
+
+  The result is a bare list rather than an ok tuple, and is empty when nothing matches.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{shop_name: "one-user.myshopify.com", app_name: "my-app", associated_user_id: 1}
+      iex> ShopifyAPI.UserTokenServer.set(token)
+      iex> ShopifyAPI.UserTokenServer.get_for_shop("one-user.myshopify.com")
+      [token]
+
+      iex> ShopifyAPI.UserTokenServer.get_for_shop("unknown.myshopify.com")
+      []
+
+  """
+  @spec get_for_shop(String.t()) :: [t()]
   def get_for_shop(myshopify_domain) when is_binary(myshopify_domain) do
     match_spec = [{{{myshopify_domain, :_, :_}, :"$1"}, [], [:"$1"]}]
     :ets.select(@table, match_spec)
   end
 
+  @doc """
+  Returns every cached token issued for an app, across all shops and users.
+
+  Like `get_for_shop/1`, the result is a bare list and is empty when nothing matches.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{shop_name: "shop.myshopify.com", app_name: "my-report-app", associated_user_id: 1}
+      iex> ShopifyAPI.UserTokenServer.set(token)
+      iex> ShopifyAPI.UserTokenServer.get_for_app("my-report-app")
+      [token]
+
+  """
+  @spec get_for_app(String.t()) :: [t()]
   def get_for_app(app) when is_binary(app) do
     match_spec = [{{{:_, app, :_}, :"$1"}, [], [:"$1"]}]
     :ets.select(@table, match_spec)
   end
 
+  @doc """
+  Removes one user's token from the cache.
+
+  Takes the token struct itself, since the cache key spans three fields — unlike
+  `ShopifyAPI.AuthTokenServer.delete/2`, which takes a shop and an app name.
+
+  The persistence callback is not called, so delete from your own storage as well.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.UserToken{shop_name: "closing.myshopify.com", app_name: "my-app", associated_user_id: 1}
+      iex> ShopifyAPI.UserTokenServer.set(token)
+      iex> ShopifyAPI.UserTokenServer.delete(token)
+      :ok
+      iex> ShopifyAPI.UserTokenServer.get_for_shop("closing.myshopify.com")
+      []
+
+  """
   @spec delete(UserToken.t()) :: :ok
   def delete(token) do
     :ets.delete(@table, {token.shop_name, token.app_name, token.associated_user_id})
     :ok
   end
 
+  @doc """
+  Removes every user's token for a shop from the cache.
+
+  This is what an `app/uninstalled` webhook wants, since a shop that has uninstalled leaves one
+  stale token behind per staff member. `ShopifyAPI.AuthTokenServer` has no equivalent — clear
+  the offline token with `ShopifyAPI.AuthTokenServer.delete/2` alongside this.
+
+  As with `delete/1`, persisted tokens are untouched.
+
+  ## Examples
+
+      iex> first = %ShopifyAPI.UserToken{shop_name: "gone.myshopify.com", app_name: "my-app", associated_user_id: 1}
+      iex> second = %ShopifyAPI.UserToken{shop_name: "gone.myshopify.com", app_name: "my-app", associated_user_id: 2}
+      iex> ShopifyAPI.UserTokenServer.set(first)
+      iex> ShopifyAPI.UserTokenServer.set(second)
+      iex> ShopifyAPI.UserTokenServer.delete_for_shop("gone.myshopify.com")
+      :ok
+      iex> ShopifyAPI.UserTokenServer.get_for_shop("gone.myshopify.com")
+      []
+
+  """
   @spec delete_for_shop(String.t()) :: :ok
   def delete_for_shop(myshopify_domain) when is_binary(myshopify_domain) do
     myshopify_domain |> get_for_shop() |> Enum.each(&delete/1)
     :ok
   end
 
+  @doc """
+  Removes every token from the cache, for every shop and user.
+
+  As with `delete/1`, persisted tokens are left alone and the initializer repopulates the cache
+  on the next restart.
+  """
+  @spec drop_all() :: true
   def drop_all, do: :ets.delete_all_objects(@table)
 
   ## GenServer Callbacks

--- a/mix.exs
+++ b/mix.exs
@@ -19,10 +19,40 @@ defmodule Plug.ShopifyAPI.MixProject do
 
       # Ex_Doc configuration
       name: "Shopify API",
-      source_url: "https://github.com/pixelunion/elixir-shopifyapi",
-      docs: [
-        main: "ShopifyAPI.App",
-        extras: ["README.md"]
+      source_url: "https://github.com/orbit-apps/elixir-shopifyapi",
+      docs: docs()
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      extras: ["README.md", "guides/authentication.md", "CHANGELOG.md"],
+      groups_for_extras: [Guides: ~r/guides\//],
+      source_ref: "v#{@version}",
+      groups_for_modules: [
+        Authentication: [
+          ShopifyAPI.App,
+          ShopifyAPI.AuthRequest,
+          ShopifyAPI.AuthToken,
+          ShopifyAPI.AssociatedUser,
+          ShopifyAPI.JWTSessionToken,
+          ShopifyAPI.Router,
+          ShopifyAPI.Security,
+          ShopifyAPI.Shop,
+          ShopifyAPI.UserToken
+        ],
+        Caches: [
+          ShopifyAPI.AppServer,
+          ShopifyAPI.AuthTokenServer,
+          ShopifyAPI.ShopServer,
+          ShopifyAPI.UserTokenServer,
+          ShopifyAPI.Supervisor
+        ],
+        Plugs: [~r/^ShopifyAPI\.Plugs\./],
+        REST: [~r/^ShopifyAPI\.REST/],
+        GraphQL: [~r/^ShopifyAPI\.GraphQL/, ~r/^ShopifyAPI\.Bulk/],
+        "Rate Limiting": [~r/^ShopifyAPI\.RateLimiting/, ShopifyAPI.Throttled]
       ]
     ]
   end

--- a/test/shopify_api/auth_token_server_test.exs
+++ b/test/shopify_api/auth_token_server_test.exs
@@ -1,0 +1,8 @@
+defmodule ShopifyAPI.AuthTokenServerTest do
+  use ExUnit.Case, async: true
+
+  # The ETS table is public and shared across the whole suite, so each example keys its tokens
+  # on a shop and app pair that no other example or test uses. The rest of the suite builds
+  # shop names with Faker, so the plain names in the docs cannot collide with them.
+  doctest ShopifyAPI.AuthTokenServer
+end

--- a/test/shopify_api/security_test.exs
+++ b/test/shopify_api/security_test.exs
@@ -1,0 +1,5 @@
+defmodule ShopifyAPI.SecurityTest do
+  use ExUnit.Case, async: true
+
+  doctest ShopifyAPI.Security
+end

--- a/test/shopify_api/shop_test.exs
+++ b/test/shopify_api/shop_test.exs
@@ -1,0 +1,5 @@
+defmodule ShopifyAPI.ShopTest do
+  use ExUnit.Case, async: true
+
+  doctest ShopifyAPI.Shop
+end

--- a/test/shopify_api/user_token_server_test.exs
+++ b/test/shopify_api/user_token_server_test.exs
@@ -1,0 +1,7 @@
+defmodule ShopifyAPI.UserTokenServerTest do
+  use ExUnit.Case, async: true
+
+  # The ETS table is public and shared across the whole suite, so each example keys its tokens
+  # on a shop, app and user id that no other example or test uses.
+  doctest ShopifyAPI.UserTokenServer
+end


### PR DESCRIPTION
Groundwork for expiring offline access tokens. Shopify now issues offline tokens that expire after an hour and carry a refresh token, and supporting them means a refresh token server following the same pattern as AuthTokenServer. Documenting the current behaviour first makes that change a diff against real docs rather than a from-scratch write.

The modules on the auth path were largely undocumented. Router, Shop, JWTSessionToken and Security had no moduledoc at all; AuthTokenServer, UserTokenServer, AppServer and ShopServer each had a single line that said "write-through cache" and nothing about the initializer/persistence contract apps have to implement. AuthRequest described only post/3 and predated the two token-exchange functions beside it.

Documented, with @doc and @spec on every public function:

  - AuthTokenServer and UserTokenServer, including the callback contract, that delete/2 and drop_all/0 bypass persistence, that a raising persistence callback propagates into the OAuth callback, and that get_valid/3 reports "expired" and "missing" identically
  - Router, AuthRequest, App, Shop, JWTSessionToken, Security
  - AppServer and ShopServer, covering how each differs from the token caches
  - guides/authentication.md, tying the pieces together for an app that mounts the Router

Examples are doctests rather than illustrative snippets. The README had `token = AuthTokenServer.get(...)` when get/2 returns {:ok, token}, which is the failure mode doctests exist to prevent; 22 of them now run in the suite. Setup stays inline in each example, following Process.put/get/delete and Agent in the standard library, so an example can be pasted into iex.

Fixes found while writing:

  - JWTSessionToken used @doc where it meant @moduledoc, so its module description was rendering as the summary for verify/2
  - JWTSessionToken.get_offline_token/2 declared the error atom of the online exchange
  - AuthToken's timestamp was typed as the literal 0 rather than integer()
  - the 0.16.6 CHANGELOG entry credited Bulk.Query.exec/3, which is exec!/3
  - four AuthTokenServer and four UserTokenServer functions had no @spec

ExDoc now opens on the README, includes the guide and CHANGELOG, groups ~60 modules instead of listing them flat, and links to source at the tagged version. source_url moves to orbit-apps; with source_ref added, the old pixelunion URL would have made every "view source" link a 404.

No behaviour changes.

AL-136