### PR TITLE
Support expiring offline access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 ## Unreleased
 
+Support for Shopify's expiring offline access tokens. Shopify has required them of new public
+apps since April 2026 and stops accepting permanent ones on 1 January 2027.
+
+- BREAKING: `ShopifyAPI.AuthTokenServer.get/2` now returns `{:error, :not_found}` instead of
+  `{:error, "Auth token for shop:app could not be found."}`. Guards matching a binary error
+  term will fall through.
+- BREAKING: `ShopifyAPI.AuthTokenServer.set/2` persists *before* writing to the cache, and
+  raises on failure — `ShopifyAPI.TokenPersistenceError` for an `{:error, _}` return, or the
+  callback's own exception. Callbacks that log and return on failure must now raise; prefer
+  `Repo.insert!/2`.
+- Changed: `ShopifyAPI.Plugs.AdminAuthenticator`, `ShopifyAPI.Plugs.AuthShopSessionToken` and
+  `ShopifyAPI.JWTSessionToken.get_offline_token/2` read offline tokens through
+  `ShopifyAPI.AuthToken.fetch/2`, so they refresh an expiring token when needed.
+  `AuthShopSessionToken` now exchanges the session token when no offline token is usable,
+  rather than responding `401`. A failed refresh raises `ShopifyAPI.TokenRefreshError` from
+  all three rather than being treated as a missing token.
+- New: `ShopifyAPI.AuthToken` fields `token_expires_at`, `refresh_token` and
+  `refresh_token_expires_at`. All default to `nil`, so existing `%AuthToken{}` fixtures
+  describe a permanent token.
+- New: `ShopifyAPI.AuthToken.fetch/2` — the accessor application code should read tokens
+  through. Checks expiry and refreshes when needed. `ShopifyAPI.AuthTokenServer.get/2`
+  remains the bare cache read.
+- New: `ShopifyAPI.AuthToken.status/2` — checks whether a shop's token is usable without
+  refreshing.
+- New: `ShopifyAPI.AuthToken.apply_refresh/5` — replaces the credential pair while keeping
+  non-credential fields (`plus`, `shop_name`, etc.) from the original token.
+- New: `ShopifyAPI.AuthToken.validate_pair/1` — checks that a token has an access token and
+  that its expiring fields are all set or all absent, with the refresh token outliving the
+  access token. Acquisition applies it before returning a token; tokens an initializer loads
+  are not checked.
+- New: `ShopifyAPI.AuthToken.refresh_outlives_access?/1` — whether a token's refresh token
+  expires after its access token; the rule both acquisition and refresh enforce.
+- New: `ShopifyAPI.Refresh` — runs, schedules and de-duplicates token refreshes.
+  `shops_needing_refresh/1` selects tokens for a scheduled sweep.
+- New: `ShopifyAPI.TokenRefreshError` — raised when a refresh fails for any reason other than
+  a dead refresh token. It carries `plug_status: 503`, so Plug renders it as a `503`.
+- New: `ShopifyAPI.RefreshSupervisor`, started by `ShopifyAPI.Supervisor`. Isolates refresh
+  failures from the restart budget shared by the caches.
+- New: `ShopifyAPI.Test` — builders for auth token states (live, expired, dead).
+- New: configuration — `:expiring` to acquire expiring tokens; `:refresh_threshold_seconds`,
+  `:refresh_wait_timeout_ms` and `:refresh_retry` to tune refreshing. `:expiring` controls
+  new token requests only; tokens that already carry a refresh token are refreshed regardless.
+- New: `ShopifyAPI.AuthToken` derives `Inspect` excluding `token`, `refresh_token` and `code`.
+
 ## 0.16.6
 
 - New: Add support for passing options to `ShopifyAPI.Bulk.Query.exec!/3`, with `group_objects`

--- a/README.md
+++ b/README.md
@@ -115,9 +115,27 @@ survive restarts: the `initializer` hook loads tokens back in at boot, and the
 Both hooks are optional, and without them tokens live only in memory and are
 lost when the application stops.
 
-See the `ShopifyAPI.AuthTokenServer` documentation for the full contract - the
-arguments each hook receives, the traps around deleting tokens and handling app
-uninstalls, and a worked Ecto example. Per-user online tokens are handled
+Read tokens back with `ShopifyAPI.AuthToken.fetch/2`, which checks expiry and
+refreshes when needed:
+
+```elixir
+case ShopifyAPI.AuthToken.fetch(myshopify_domain, "my-app") do
+  {:ok, auth_token} -> do_the_work(auth_token)
+  {:error, :not_found} -> cancel("shop has no token")
+  {:error, :needs_reacquisition} -> cancel_and_flag(shop)
+end
+```
+
+Any other failure, such as a Shopify outage or a failed write, raises; let your
+job's retry handle it.
+
+Shopify's expiring offline tokens last an hour. Set
+`config :shopify_api, expiring: true` to acquire them; see the
+[Authentication guide](guides/authentication.md) for the full picture.
+
+`ShopifyAPI.AuthTokenServer` documents the caching contract itself — the
+arguments each hook receives, the traps around deleting tokens and handling
+app uninstalls, and a worked Ecto example. Per-user online tokens are handled
 separately by `ShopifyAPI.UserTokenServer`.
 
 ## Webhooks
@@ -157,7 +175,7 @@ Now once a shop is installed, you can create webhook subscriptions.
 This will automatically append your app's name to the generated webhook URL:
 
 ```elixir
-{:ok, token} = ShopifyAPI.AuthTokenServer.get("shop domain", "app name")
+{:ok, token} = ShopifyAPI.AuthToken.fetch("shop domain", "app name")
 
 topic = "orders/create"
 server_address = ShopifyAPI.REST.Webhook.webhook_uri(token)
@@ -226,4 +244,5 @@ defmodule Instrumenter do
   def handle_event([:shopify_api, :rest_request, :success], measurements, metadata, _config) do
     # Ship success events
   end
-end```
+end
+```

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -147,6 +147,72 @@ same things.
 Either way your controllers read `conn.assigns.auth_token` and hand it to
 `ShopifyAPI.REST` or `ShopifyAPI.GraphQL`.
 
+Any time a module needs a token to call the Shopify API, read it with
+`ShopifyAPI.AuthToken.fetch/2`:
+
+```elixir
+case ShopifyAPI.AuthToken.fetch(shop.domain, MyApp.app_name()) do
+  {:ok, auth_token} -> do_the_work(auth_token)
+  {:error, :not_found} -> cancel("shop has no token")
+  {:error, :needs_reacquisition} -> cancel_and_flag(shop)
+end
+```
+
+Any other failure raises: `ShopifyAPI.TokenRefreshError` when Shopify fails
+the refresh, and `ShopifyAPI.TokenPersistenceError` when the new pair cannot
+be stored. A background job should let either propagate and be retried. In a
+request, Plug renders a failed refresh as a `503`, and neither plug above
+treats it as a missing token.
+
+`ShopifyAPI.AuthTokenServer.get/2` returns whatever the cache holds, expired or
+not. `fetch/2` checks the expiry and refreshes when needed.
+
+## Expiring tokens
+
+Shopify issues offline tokens in two shapes. A _permanent_ token never expires.
+An _expiring_ token lives for an hour and comes with a refresh token; refreshing
+replaces both the access token and the refresh token at once.
+
+Shopify has required expiring tokens of new public apps since April 2026 and
+stops accepting permanent ones on 1 January 2027.
+
+### Opting in
+
+```elixir
+config :shopify_api, expiring: true
+```
+
+This applies to new token requests — both the OAuth code grant and token
+exchange. A token that already carries a refresh token is refreshed regardless
+of this setting, so turning it off does not strand shops that already have one.
+
+### Scheduled refreshing
+
+`ShopifyAPI.AuthToken.fetch/2` refreshes tokens automatically, so shops with
+active API callers stay current. Your application is responsible for refreshing
+inactive shops — a refresh token that is never used lapses after ninety days.
+
+Shopify replays a refresh token for **thirty days** after its first use — if a
+refreshed pair reaches the cache but not your database, or you restore an older
+backup, the stale refresh token still works within that window. Schedule a sweep
+on a shorter cadence to keep every shop inside it.
+`ShopifyAPI.Refresh.shops_needing_refresh/1` selects the tokens due.
+
+### Persistence changes
+
+Your persistence callback needs three additional columns: `token_expires_at`,
+`refresh_token` and `refresh_token_expires_at`. All three must appear in the
+Ecto `:replace` list — omitting any of them silently preserves stale values, and
+the token stops working when the old refresh token expires.
+
+The callback must raise on write failure rather than logging and returning. See
+`ShopifyAPI.AuthTokenServer` for why and a worked Ecto example.
+
+### Testing
+
+`ShopifyAPI.Test` builds tokens in each expiry state: live, expired but
+refreshable, and dead.
+
 ## Uninstalling
 
 Shopify revokes the token and sends an `app/uninstalled` webhook. Nothing in

--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -86,9 +86,18 @@ defmodule ShopifyAPI.App do
     {:ok, UserToken.from_auth_request(app, domain, auth_code, json)}
   end
 
-  defp create_token(%{"access_token" => token}, app, domain, auth_code) do
+  defp create_token(%{"access_token" => _} = json, app, domain, auth_code) do
     Logger.debug("offline token")
-    {:ok, AuthToken.new(app, domain, auth_code, token)}
+    token = AuthToken.from_auth_request(app, domain, auth_code, json)
+
+    case AuthToken.validate_pair(token) do
+      :ok ->
+        {:ok, token}
+
+      {:error, reason} ->
+        Logger.warning("#{__MODULE__} [#{domain}] unusable offline token: #{reason}")
+        {:error, "Unable to create token"}
+    end
   end
 
   defp create_token(_, _, _, _), do: {:error, "Unable to create token"}

--- a/lib/shopify_api/auth_request.ex
+++ b/lib/shopify_api/auth_request.ex
@@ -35,6 +35,7 @@ defmodule ShopifyAPI.AuthRequest do
   alias ShopifyAPI.App
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.Config
   alias ShopifyAPI.JSONSerializer
   alias ShopifyAPI.UserToken
   alias ShopifyAPI.UserTokenServer
@@ -51,11 +52,12 @@ defmodule ShopifyAPI.AuthRequest do
   @spec post(ShopifyAPI.App.t(), String.t() | list(), String.t()) ::
           {:ok, any()} | {:error, any()}
   def post(app, myshopify_domain, auth_code) when is_struct(app, App) do
-    http_body = %{
-      client_id: app.client_id,
-      client_secret: app.client_secret,
-      code: auth_code
-    }
+    http_body =
+      request_expiring(%{
+        client_id: app.client_id,
+        client_secret: app.client_secret,
+        code: auth_code
+      })
 
     access_token_url = myshopify_domain |> base_uri() |> URI.to_string()
 
@@ -77,7 +79,8 @@ defmodule ShopifyAPI.AuthRequest do
   Exchanges a session token for the shop's offline access token.
 
   Writes the token to `ShopifyAPI.AuthTokenServer` — and so through your configured persistence
-  callback — before returning it.
+  callback — before returning it. Returns `{:error, :failed_fetching_offline_token}`, storing
+  nothing, when the exchange fails or its response carries an incomplete or inconsistent pair.
 
   Shopify docs:
     - [Session tokens](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens/set-up-session-tokens)
@@ -86,29 +89,164 @@ defmodule ShopifyAPI.AuthRequest do
   @spec request_offline_access_token(App.t(), String.t(), String.t()) ::
           {:ok, AuthToken.t()} | {:error, :failed_fetching_offline_token}
   def request_offline_access_token(app, myshopify_domain, session_token) do
-    http_body = %{
-      client_id: app.client_id,
-      client_secret: app.client_secret,
-      grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-      subject_token: session_token,
-      subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
-      requested_token_type: "urn:shopify:params:oauth:token-type:offline-access-token"
-    }
+    http_body =
+      request_expiring(%{
+        client_id: app.client_id,
+        client_secret: app.client_secret,
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        subject_token: session_token,
+        subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+        requested_token_type: "urn:shopify:params:oauth:token-type:offline-access-token"
+      })
 
     access_token_url = myshopify_domain |> base_uri() |> URI.to_string()
     encoded_body = JSONSerializer.encode!(http_body)
 
-    case HTTPoison.post(access_token_url, encoded_body, @headers) do
-      {:ok, %{status_code: 200, body: body}} ->
-        json = JSONSerializer.decode!(body)
-        token = AuthToken.from_auth_request(app, myshopify_domain, json)
-        AuthTokenServer.set(token)
-        {:ok, token}
-
+    with {:ok, %{status_code: 200, body: body}} <-
+           HTTPoison.post(access_token_url, encoded_body, @headers),
+         json = JSONSerializer.decode!(body),
+         token = AuthToken.from_auth_request(app, myshopify_domain, json),
+         :ok <- AuthToken.validate_pair(token) do
+      AuthTokenServer.set(token)
+      {:ok, token}
+    else
+      # A rejected pair lands here as `{:error, reason}`, so the 200 body and the credentials
+      # it carries are never logged.
       err ->
-        Logger.error("error creating token #{inspect(err)}")
+        Logger.error("error creating token #{inspect(sanitize_for_logging(err))}")
         {:error, :failed_fetching_offline_token}
     end
+  end
+
+  @doc """
+  Trades a token's refresh token for a fresh pair, and stores the result.
+
+  Shopify rotates both halves at once: the response carries a new access token and a new
+  refresh token. Both are written to `ShopifyAPI.AuthTokenServer` before returning.
+
+  Returns `{:error, :needs_reacquisition}` when Shopify rejects the refresh token (expired or
+  superseded). All other failures (assumed to be transient) raise `ShopifyAPI.TokenRefreshError`.
+
+  `ShopifyAPI.Refresh` wraps this with retry and de-duplication.
+
+  Shopify docs:
+    - [Offline access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens)
+  """
+  @spec refresh_offline_access_token(App.t(), AuthToken.t()) ::
+          AuthToken.ok_t() | AuthToken.needs_reacquisition()
+  def refresh_offline_access_token(app, %AuthToken{refresh_token: refresh_token} = token)
+      when is_struct(app, App) and is_binary(refresh_token) do
+    http_body = %{
+      client_id: app.client_id,
+      client_secret: app.client_secret,
+      grant_type: "refresh_token",
+      refresh_token: refresh_token
+    }
+
+    access_token_url = token.shop_name |> base_uri() |> URI.to_string()
+    encoded_body = JSONSerializer.encode!(http_body)
+
+    Logger.debug("#{__MODULE__} refreshing token for #{AuthToken.create_key(token)}")
+
+    case HTTPoison.post(access_token_url, encoded_body, @headers) do
+      {:ok, %{status_code: 200, body: body}} ->
+        refreshed = body |> decode_body!(token) |> refreshed_token!(token)
+
+        AuthTokenServer.set(refreshed)
+
+        Logger.debug(
+          "#{__MODULE__} refreshed #{AuthToken.create_key(token)}, access token now expires " <>
+            "#{refreshed.token_expires_at}, refresh token #{refreshed.refresh_token_expires_at}"
+        )
+
+        {:ok, refreshed}
+
+      # Refresh token rejected — expired or superseded.
+      {:ok, %{status_code: 401}} ->
+        Logger.warning(
+          "#{__MODULE__} refresh token rejected for #{token.shop_name}:#{token.app_name}"
+        )
+
+        {:error, :needs_reacquisition}
+
+      other ->
+        raise ShopifyAPI.TokenRefreshError,
+          message:
+            "Refreshing #{token.shop_name}:#{token.app_name} failed: " <>
+              "#{inspect(sanitize_for_logging(other))}"
+    end
+  end
+
+  # Decodes a refresh response body. The decode error is dropped rather than quoted, since it can
+  # carry the body and so the credentials in it.
+  @spec decode_body!(String.t(), AuthToken.t()) :: term()
+  defp decode_body!(body, token) do
+    case JSONSerializer.decode(body) do
+      {:ok, json} ->
+        json
+
+      _error ->
+        raise ShopifyAPI.TokenRefreshError,
+          message:
+            "Refresh for #{token.shop_name}:#{token.app_name} returned a body that is not JSON"
+    end
+  end
+
+  # Builds the refreshed token from a `refresh_token` grant response.
+  #
+  # A refresh always returns a complete rotating pair: a new access token, and a new refresh
+  # token that outlives it. Requiring all four fields here catches an incomplete response at
+  # the source, rather than storing a token with nil expiries and tripping over it later.
+  @spec refreshed_token!(map(), AuthToken.t()) :: AuthToken.t()
+  defp refreshed_token!(
+         %{
+           "access_token" => access_token,
+           "expires_in" => expires_in,
+           "refresh_token" => refresh_token,
+           "refresh_token_expires_in" => refresh_token_expires_in
+         },
+         token
+       )
+       when is_binary(access_token) and is_integer(expires_in) and
+              is_binary(refresh_token) and is_integer(refresh_token_expires_in) do
+    refreshed =
+      AuthToken.apply_refresh(
+        token,
+        access_token,
+        expires_in,
+        refresh_token,
+        refresh_token_expires_in
+      )
+
+    # Guards against a refresh token that expires no later than the access token it renews,
+    # which would strand the shop on its next refresh.
+    if AuthToken.refresh_outlives_access?(refreshed) do
+      refreshed
+    else
+      raise ShopifyAPI.TokenRefreshError,
+        message:
+          "Refresh for #{token.shop_name}:#{token.app_name} returned a refresh token expiring " <>
+            "at #{refreshed.refresh_token_expires_at}, no later than its access token at " <>
+            "#{refreshed.token_expires_at}"
+    end
+  end
+
+  defp refreshed_token!(_attrs, token) do
+    raise ShopifyAPI.TokenRefreshError,
+      message: "Refresh for #{token.shop_name}:#{token.app_name} returned an incomplete pair"
+  end
+
+  # Reduces an HTTP result to the fields safe to log or surface in an exception, dropping the
+  # request (which carries the client secret and token).
+  defp sanitize_for_logging({:ok, %{status_code: status, body: body}}),
+    do: %{status: status, body: body}
+
+  defp sanitize_for_logging({:error, %HTTPoison.Error{reason: reason}}), do: %{reason: reason}
+  defp sanitize_for_logging(other), do: other
+
+  # Adds the `expiring` flag to new token requests. Refresh grants do not accept it.
+  defp request_expiring(http_body) do
+    if Config.expiring?(), do: Map.put(http_body, :expiring, 1), else: http_body
   end
 
   @doc """
@@ -145,7 +283,7 @@ defmodule ShopifyAPI.AuthRequest do
         {:ok, user_token}
 
       err ->
-        Logger.error("error creating token #{inspect(err)}")
+        Logger.error("error creating token #{inspect(sanitize_for_logging(err))}")
         {:error, :failed_fetching_online_token}
     end
   end

--- a/lib/shopify_api/auth_token.ex
+++ b/lib/shopify_api/auth_token.ex
@@ -7,26 +7,55 @@ defmodule ShopifyAPI.AuthToken do
   `ShopifyAPI.AuthTokenServer`, which is also where the storage callbacks that outlive a
   restart are configured.
 
-  This struct models a *non-expiring* offline token, so it carries no expiry or refresh
-  token.
+  ## Expiring and permanent tokens
+
+  Shopify issues offline tokens in two shapes, and this struct models both. A *permanent*
+  token never expires: `refresh_token` is `nil` and neither expiry is set. An *expiring*
+  token lives for an hour and arrives with a `refresh_token`; refreshing replaces both at
+  once.
+
+  A `nil` `refresh_token` distinguishes the two throughout this library. `fetch/2` returns a
+  token ready to use — refreshing an expiring one if needed, returning a permanent one as is.
+
+  Shopify has required expiring tokens of new public apps since April 2026 and stops
+  accepting permanent ones on 1 January 2027. See
+  [Offline access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens).
 
   The online, per-user counterpart is `ShopifyAPI.UserToken`. Shopify covers both in
   [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens).
   """
 
-  @derive {Jason.Encoder, only: [:code, :app_name, :shop_name, :token, :timestamp, :plus]}
+  @derive {Jason.Encoder,
+           only: [
+             :code,
+             :app_name,
+             :shop_name,
+             :token,
+             :timestamp,
+             :plus,
+             :token_expires_at,
+             :refresh_token,
+             :refresh_token_expires_at
+           ]}
+  @derive {Inspect, except: [:code, :token, :refresh_token]}
   defstruct code: "",
             app_name: "",
             shop_name: "",
             token: "",
             timestamp: 0,
-            plus: false
+            plus: false,
+            token_expires_at: nil,
+            refresh_token: nil,
+            refresh_token_expires_at: nil
 
   @typedoc """
       Type that represents a Shopify Auth Token with
 
         - app_name corresponding to %ShopifyAPI.App{name: app_name}
         - shop_name corresponding to %ShopifyAPI.Shop{domain: shop_name}
+
+  The three nullable fields are set together or not at all: they are populated for an
+  expiring token and `nil` for a permanent one. `validate_pair/1` checks this.
   """
   @type t :: %__MODULE__{
           code: String.t(),
@@ -34,11 +63,156 @@ defmodule ShopifyAPI.AuthToken do
           shop_name: String.t(),
           token: String.t(),
           timestamp: integer(),
-          plus: boolean()
+          plus: boolean(),
+          token_expires_at: DateTime.t() | nil,
+          refresh_token: String.t() | nil,
+          refresh_token_expires_at: DateTime.t() | nil
         }
   @type ok_t :: {:ok, t()}
 
+  @typedoc "No token cached for this shop and app."
+  @type not_found :: {:error, :not_found}
+
+  @typedoc "Token exists but its refresh token has expired; a new token must be obtained."
+  @type needs_reacquisition :: {:error, :needs_reacquisition}
+
+  @typedoc "Every error `fetch/2` can return."
+  @type fetch_error :: not_found() | needs_reacquisition()
+
+  @typedoc "The result of `fetch/2`."
+  @type fetch_result :: ok_t() | fetch_error()
+
+  @typedoc "The result of `status/2`: the same three outcomes without the token."
+  @type status :: :ok | :needs_reacquisition | :not_found
+
+  require Logger
+
   alias ShopifyAPI.App
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.Refresh
+
+  @doc """
+  Returns a usable token for a shop and app, refreshing if needed.
+
+  A permanent token is returned as is. An expiring token is checked against
+  `ShopifyAPI.Refresh.threshold/0`:
+
+    - **Above the threshold** — returned immediately, no refresh.
+    - **Below the threshold** — returned immediately, background refresh starts.
+    - **Expired** — caller waits for a refresh before receiving the new token.
+
+  Returns `{:error, :not_found}` when nothing is cached, and
+  `{:error, :needs_reacquisition}` when the token's refresh token has expired — a new token
+  must be obtained via OAuth or token exchange. All other failures (assumed to be transient)
+  raise.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "fetch.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token, false)
+      iex> ShopifyAPI.AuthToken.fetch("fetch.myshopify.com", "my-app")
+      {:ok, token}
+
+      # Assuming nothing has been stored for the shop
+      iex> ShopifyAPI.AuthToken.fetch("unknown.myshopify.com", "my-app")
+      {:error, :not_found}
+
+  """
+  @spec fetch(String.t(), String.t()) :: fetch_result()
+  def fetch(myshopify_domain, app_name)
+      when is_binary(myshopify_domain) and is_binary(app_name) do
+    with {:ok, token} <- AuthTokenServer.get(myshopify_domain, app_name) do
+      resolve(token)
+    end
+  end
+
+  # A permanent token: nothing to check and nothing that could refresh it.
+  #
+  # TODO(2026-12-01): return `{:error, :needs_reacquisition}` here once every shop is migrated.
+  # Shopify stops accepting permanent tokens on 2027-01-01, after which this hands back a token
+  # the Admin API answers 403. Change the branch rather than deleting it — without it a permanent
+  # token falls through to the expiring path and raises on a refresh it has no token for.
+  defp resolve(%__MODULE__{refresh_token: nil} = token), do: {:ok, token}
+
+  defp resolve(%__MODULE__{} = token) do
+    now = DateTime.utc_now()
+    remaining = remaining_ms(token.token_expires_at, now)
+    refresh_dead? = dead?(token.refresh_token_expires_at, now)
+
+    cond do
+      remaining > Refresh.threshold() ->
+        {:ok, token}
+
+      # Still valid — return it, and start a background refresh if the refresh token is alive.
+      remaining > 0 ->
+        unless refresh_dead?, do: Refresh.run_in_background(token)
+        {:ok, token}
+
+      refresh_dead? ->
+        Logger.debug(
+          "#{__MODULE__} refresh token for #{create_key(token)} expired " <>
+            "#{token.refresh_token_expires_at}, needs new token"
+        )
+
+        {:error, :needs_reacquisition}
+
+      true ->
+        Refresh.await_or_run(token)
+    end
+  end
+
+  @doc """
+  Checks whether a shop's token can still serve API calls — essentially whether
+  the refresh token is still alive.
+
+  A cache read only — no Shopify round trip and no refresh.
+
+    - `:ok` — permanent, live, or expired with a live refresh token.
+    - `:needs_reacquisition` — both halves expired; a new token must be obtained.
+    - `:not_found` — nothing cached for this shop and app.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "status.myshopify.com", app_name: "my-app"}
+      iex> ShopifyAPI.AuthTokenServer.set(token, false)
+      iex> ShopifyAPI.AuthToken.status("status.myshopify.com", "my-app")
+      :ok
+
+      iex> ShopifyAPI.AuthToken.status("unknown.myshopify.com", "my-app")
+      :not_found
+
+  """
+  @spec status(String.t(), String.t()) :: status()
+  def status(myshopify_domain, app_name)
+      when is_binary(myshopify_domain) and is_binary(app_name) do
+    case AuthTokenServer.get(myshopify_domain, app_name) do
+      {:error, :not_found} ->
+        :not_found
+
+      {:ok, %__MODULE__{refresh_token: nil}} ->
+        :ok
+
+      {:ok, token} ->
+        now = DateTime.utc_now()
+
+        if remaining_ms(token.token_expires_at, now) <= 0 and
+             dead?(token.refresh_token_expires_at, now) do
+          :needs_reacquisition
+        else
+          :ok
+        end
+    end
+  end
+
+  # A missing expiry is treated as expired — refreshing repairs the record.
+  defp remaining_ms(nil, _now), do: 0
+
+  defp remaining_ms(%DateTime{} = expires_at, now),
+    do: DateTime.diff(expires_at, now, :millisecond)
+
+  # A missing refresh-token expiry is not treated as dead — let Shopify decide.
+  defp dead?(nil, _now), do: false
+  defp dead?(%DateTime{} = expires_at, now), do: DateTime.compare(expires_at, now) != :gt
 
   @spec create_key(t()) :: String.t()
   def create_key(%__MODULE__{shop_name: shop, app_name: app}), do: create_key(shop, app)
@@ -46,6 +220,20 @@ defmodule ShopifyAPI.AuthToken do
   @spec create_key(String.t(), String.t()) :: String.t()
   def create_key(shop, app), do: "#{shop}:#{app}"
 
+  @doc """
+  Builds a permanent token from an access token string.
+
+  Carries no expiry and no refresh token. See `from_auth_request/4` for the constructor that
+  handles expiring tokens.
+
+  ## Examples
+
+      iex> app = %ShopifyAPI.App{name: "my-app"}
+      iex> token = ShopifyAPI.AuthToken.new(app, "shop.myshopify.com", "auth-code", "shpat_abc")
+      iex> token.refresh_token
+      nil
+
+  """
   @spec new(App.t(), String.t(), String.t(), String.t()) :: t()
   def new(app, myshopify_domain, auth_code, token) do
     %__MODULE__{
@@ -56,8 +244,171 @@ defmodule ShopifyAPI.AuthToken do
     }
   end
 
+  @doc """
+  Builds a token from a parsed access token response.
+
+  Populates the refresh token and both expiries for an expiring token; leaves all three `nil`
+  for a permanent one. Expiries are computed from the response's `expires_in` and
+  `refresh_token_expires_in` fields, which are durations in seconds.
+
+  ## Examples
+
+      iex> app = %ShopifyAPI.App{name: "my-app"}
+      iex> attrs = %{
+      ...>   "access_token" => "shpat_abc",
+      ...>   "expires_in" => 3600,
+      ...>   "refresh_token" => "shprt_xyz",
+      ...>   "refresh_token_expires_in" => 7_775_999
+      ...> }
+      iex> token = ShopifyAPI.AuthToken.from_auth_request(app, "shop.myshopify.com", attrs)
+      iex> token.refresh_token
+      "shprt_xyz"
+      iex> DateTime.compare(token.token_expires_at, DateTime.utc_now())
+      :gt
+
+      # A permanent token response carries none of the three
+      iex> app = %ShopifyAPI.App{name: "my-app"}
+      iex> token = ShopifyAPI.AuthToken.from_auth_request(app, "shop.myshopify.com", %{"access_token" => "shpat_abc"})
+      iex> {token.refresh_token, token.token_expires_at, token.refresh_token_expires_at}
+      {nil, nil, nil}
+
+  """
   @spec from_auth_request(App.t(), String.t(), String.t(), map()) :: t()
   def from_auth_request(app, myshopify_domain, code \\ "", attrs) when is_struct(app, App) do
-    new(app, myshopify_domain, code, attrs["access_token"])
+    now = DateTime.utc_now()
+
+    %__MODULE__{
+      app_name: app.name,
+      shop_name: myshopify_domain,
+      code: code,
+      token: attrs["access_token"],
+      token_expires_at: expires_at(now, attrs["expires_in"]),
+      refresh_token: attrs["refresh_token"],
+      refresh_token_expires_at: expires_at(now, attrs["refresh_token_expires_in"])
+    }
   end
+
+  @doc """
+  Swaps a refreshed credential set into the token it renewed.
+
+  Replaces the access token, refresh token and both expiries — the latter computed from the
+  `expires_in` and `refresh_token_expires_in` durations, in seconds. All other fields —
+  `plus`, `shop_name`, `app_name` — are kept from the original, since a refresh grant returns
+  only credentials.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{shop_name: "shop.myshopify.com", app_name: "my-app", plus: true}
+      iex> refreshed = ShopifyAPI.AuthToken.apply_refresh(token, "shpat_new", 3600, "shprt_new", 7_775_999)
+      iex> {refreshed.token, refreshed.plus}
+      {"shpat_new", true}
+
+  """
+  @spec apply_refresh(t(), String.t(), pos_integer(), String.t(), pos_integer()) :: t()
+  def apply_refresh(
+        %__MODULE__{} = token,
+        token_value,
+        expires_in,
+        refresh_token,
+        refresh_token_expires_in
+      ) do
+    now = DateTime.utc_now()
+
+    %__MODULE__{
+      token
+      | token: token_value,
+        token_expires_at: expires_at(now, expires_in),
+        refresh_token: refresh_token,
+        refresh_token_expires_at: expires_at(now, refresh_token_expires_in)
+    }
+  end
+
+  @doc """
+  Checks that a token's credentials are complete and consistent.
+
+  Every token needs an access token in `token`. A permanent token has none of
+  `token_expires_at`, `refresh_token` and `refresh_token_expires_at`; an expiring token has
+  all three, and its refresh token must outlive its access token — see
+  `refresh_outlives_access?/1`.
+
+  Returns `{:error, :incomplete_pair}` when the access token is missing, when only some of the
+  three are set, or when one holds a value of the wrong type, and
+  `{:error, :refresh_token_expires_first}` when the refresh token expires no later than the
+  access token.
+
+  Tokens from `ShopifyAPI.App.fetch_token/3` and
+  `ShopifyAPI.AuthRequest.request_offline_access_token/3` have already passed this check.
+  `ShopifyAPI.AuthRequest.refresh_offline_access_token/2` holds its response to a stricter
+  rule of its own, since a refresh must always return a pair. Tokens loaded by the
+  `ShopifyAPI.AuthTokenServer` initializer are cached as given; call it there to catch a row
+  missing part of its credentials.
+
+  ## Examples
+
+      iex> ShopifyAPI.AuthToken.validate_pair(%ShopifyAPI.AuthToken{token: "shpat_abc"})
+      :ok
+
+      iex> token = %ShopifyAPI.AuthToken{
+      ...>   token: "shpat_abc",
+      ...>   token_expires_at: ~U[2026-09-11 13:00:00Z],
+      ...>   refresh_token: "shprt_xyz",
+      ...>   refresh_token_expires_at: ~U[2026-12-10 13:00:00Z]
+      ...> }
+      iex> ShopifyAPI.AuthToken.validate_pair(token)
+      :ok
+      iex> ShopifyAPI.AuthToken.validate_pair(%{token | refresh_token: nil})
+      {:error, :incomplete_pair}
+
+  """
+  @spec validate_pair(t()) :: :ok | {:error, :incomplete_pair | :refresh_token_expires_first}
+  def validate_pair(%__MODULE__{
+        token_expires_at: nil,
+        refresh_token: nil,
+        refresh_token_expires_at: nil,
+        token: auth_token
+      })
+      when is_binary(auth_token),
+      do: :ok
+
+  def validate_pair(
+        %__MODULE__{
+          refresh_token_expires_at: %DateTime{},
+          refresh_token: refresh_token,
+          token_expires_at: %DateTime{},
+          token: auth_token
+        } = token
+      )
+      when is_binary(refresh_token) and is_binary(auth_token) do
+    if refresh_outlives_access?(token), do: :ok, else: {:error, :refresh_token_expires_first}
+  end
+
+  def validate_pair(%__MODULE__{}), do: {:error, :incomplete_pair}
+
+  @doc """
+  Returns whether a token's refresh token expires after its access token.
+
+  When it does not, nothing is left to renew the access token with once it expires. A token
+  without both expiries, a permanent one included, returns `false`.
+
+  ## Examples
+
+      iex> token = %ShopifyAPI.AuthToken{
+      ...>   token_expires_at: ~U[2026-09-11 13:00:00Z],
+      ...>   refresh_token_expires_at: ~U[2026-12-10 13:00:00Z]
+      ...> }
+      iex> ShopifyAPI.AuthToken.refresh_outlives_access?(token)
+      true
+
+  """
+  @spec refresh_outlives_access?(t()) :: boolean()
+  def refresh_outlives_access?(%__MODULE__{
+        token_expires_at: %DateTime{} = token_expires_at,
+        refresh_token_expires_at: %DateTime{} = refresh_token_expires_at
+      }),
+      do: DateTime.after?(refresh_token_expires_at, token_expires_at)
+
+  def refresh_outlives_access?(%__MODULE__{}), do: false
+
+  defp expires_at(_now, nil), do: nil
+  defp expires_at(now, seconds) when is_integer(seconds), do: DateTime.add(now, seconds, :second)
 end

--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -27,9 +27,10 @@ defmodule ShopifyAPI.AuthTokenServer do
   expire and are validated when read. `ShopifyAPI.App.fetch_token/3` decides which of the two
   an OAuth response produces.
 
-  This cache models Shopify's *non-expiring* offline tokens: the struct carries no expiry and
-  nothing here evicts or refreshes. Shopify also issues expiring offline tokens, which come
-  with a refresh token; those are not supported yet.
+  This cache holds both shapes of offline token — permanent and expiring — and treats them
+  alike. Nothing here inspects an expiry, evicts, or refreshes; `get/2` hands back whatever is
+  cached, live or not. `ShopifyAPI.AuthToken.fetch/2` is the accessor that checks and refreshes,
+  and is what application code should read through.
 
   Shopify documents the distinction under
   [Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens).
@@ -51,7 +52,9 @@ defmodule ShopifyAPI.AuthTokenServer do
 
   It must return an enumerable of `ShopifyAPI.AuthToken` structs. Anything in that enumerable
   which is not a `ShopifyAPI.AuthToken` struct is silently discarded. Tokens loaded this way
-  are not written back out through the persistence callback.
+  are not written back out through the persistence callback, and are not checked: a token
+  missing part of its credentials is cached as is, where
+  `ShopifyAPI.AuthToken.validate_pair/1` would reject it.
 
   It runs synchronously inside `c:GenServer.init/1`, so the supervisor blocks until it
   returns. List `ShopifyAPI.Supervisor` after anything the initializer depends on, such as
@@ -61,7 +64,7 @@ defmodule ShopifyAPI.AuthTokenServer do
 
   The persistence callback is invoked by `set/2` as
   `apply(module, function, [key, token | args])` — the cache key first, the token second, and
-  any configured arguments appended. Its return value is ignored.
+  any configured arguments appended.
 
   The `key` is the string built by `ShopifyAPI.AuthToken.create_key/1`,
   `"shop_name:app_name"`, and not the `{shop_name, app_name}` tuple the table is keyed by.
@@ -70,11 +73,22 @@ defmodule ShopifyAPI.AuthTokenServer do
   The callback runs synchronously, in the calling process — which during installation is
   Shopify's OAuth redirect.
 
-  > #### Persistence failures reach the caller {: .warning}
+  `set/2` persists *before* it writes to the cache, and treats a failure as fatal: an exception
+  from the callback propagates, and an `{:error, _}` return is raised as a
+  `ShopifyAPI.TokenPersistenceError`. Every other return value, `nil` included, is a success.
+
+  That error's message gives the reason's shape but not its contents — an atom as is, a struct
+  by its module name — because a reason such as a changeset holds the token being written.
+  Log the details from inside the callback if you need them.
+
+  > #### A callback that cannot write must raise {: .warning}
   >
-  > Exceptions raised by the callback are not rescued; they propagate out of `set/2`. Raising
-  > while a shop is installing fails the OAuth callback and leaves the install incomplete.
-  > Log the failure and return instead.
+  > An expiring token is a pair — access token and refresh token, replaced together. If the
+  > cache holds a pair that storage never received, the next refresh replaces both halves and
+  > the old pair in storage can no longer refresh. Persisting first means a failure leaves both
+  > sides on the old pair.
+  >
+  > Prefer `c:Ecto.Repo.insert!/2` over `c:Ecto.Repo.insert/2`.
 
   > #### Deletes are never persisted {: .warning}
   >
@@ -87,8 +101,6 @@ defmodule ShopifyAPI.AuthTokenServer do
   A persistence module backed by Ecto:
 
       defmodule MyApp.AuthToken do
-        require Logger
-
         alias ShopifyAPI.AuthToken
 
         def init do
@@ -97,7 +109,10 @@ defmodule ShopifyAPI.AuthTokenServer do
               shop_name: row.shop_name,
               app_name: row.app_name,
               token: row.token,
-              plus: row.plus
+              plus: row.plus,
+              token_expires_at: row.token_expires_at,
+              refresh_token: row.refresh_token,
+              refresh_token_expires_at: row.refresh_token_expires_at
             }
           end)
         end
@@ -105,23 +120,21 @@ defmodule ShopifyAPI.AuthTokenServer do
         def save(_key, %AuthToken{} = token) do
           %MyApp.Schema.AuthToken{}
           |> MyApp.Schema.AuthToken.changeset(Map.from_struct(token))
-          |> MyApp.Repo.insert(
-            on_conflict: {:replace, [:token, :plus]},
+          |> MyApp.Repo.insert!(
+            on_conflict:
+              {:replace,
+               [:token, :plus, :token_expires_at, :refresh_token, :refresh_token_expires_at]},
             conflict_target: [:shop_name, :app_name]
           )
-          |> case do
-            {:ok, _} ->
-              :ok
-
-            {:error, changeset} ->
-              Logger.error("Could not persist auth token: \#{inspect(changeset)}")
-          end
         end
       end
 
   `Map.from_struct/1` is enough here because the schema's field names match the struct's;
   `Ecto.Changeset.cast/4` discards the rest. Conflicting on `[:shop_name, :app_name]` rather
   than on `:shop_name` alone keeps a shop able to install more than one of your apps.
+
+  Every field of the pair is in the `:replace` list. Omitting any of them silently preserves
+  stale values, and the token stops working when the old refresh token expires.
 
   A callback does not have to persist everything it is handed. Matching on `app_name` routes
   several apps' tokens to different storage:
@@ -181,7 +194,11 @@ defmodule ShopifyAPI.AuthTokenServer do
   def count, do: :ets.info(@table, :size)
 
   @doc """
-  Stores a token in the cache and, by default, persists it.
+  Stores a token, persisting it before it reaches the cache.
+
+  Raises `ShopifyAPI.TokenPersistenceError` if the callback returns `{:error, _}`; an
+  exception raised inside the callback propagates untouched. In either case nothing is
+  written to the cache.
 
   Pass `false` as the second argument to update the cache alone, leaving the persistence
   callback uncalled. That is what the initializer does with the tokens it loads, since they
@@ -200,15 +217,16 @@ defmodule ShopifyAPI.AuthTokenServer do
   @spec set(AuthToken.t()) :: :ok
   @spec set(AuthToken.t(), boolean()) :: :ok
   def set(token, should_persist \\ true) when is_struct(token, AuthToken) do
+    if should_persist, do: persist!(token)
     :ets.insert(@table, {{token.shop_name, token.app_name}, token})
-    if should_persist, do: do_persist(token)
     :ok
   end
 
   @doc """
-  Fetches the token a shop issued for an app.
+  Fetches whatever token is cached for a shop and app, expired or not.
 
-  When no token is cached the error term carries a human-readable string rather than an atom.
+  A bare cache read — does not check expiry or refresh. Use `ShopifyAPI.AuthToken.fetch/2`
+  when you need a usable token.
 
   ## Examples
 
@@ -219,14 +237,14 @@ defmodule ShopifyAPI.AuthTokenServer do
 
       # Assuming nothing has been stored for the shop
       iex> ShopifyAPI.AuthTokenServer.get("unknown.myshopify.com", "my-app")
-      {:error, "Auth token for unknown.myshopify.com:my-app could not be found."}
+      {:error, :not_found}
 
   """
-  @spec get(String.t(), String.t()) :: {:ok, AuthToken.t()} | {:error, String.t()}
+  @spec get(String.t(), String.t()) :: AuthToken.ok_t() | AuthToken.not_found()
   def get(shop, app) when is_binary(shop) and is_binary(app) do
     case :ets.lookup(@table, {shop, app}) do
       [{_key, token}] -> {:ok, token}
-      [] -> {:error, "Auth token for #{shop}:#{app} could not be found."}
+      [] -> {:error, :not_found}
     end
   end
 
@@ -335,14 +353,32 @@ defmodule ShopifyAPI.AuthTokenServer do
     end
   end
 
-  # Attempts to persist an AuthToken if a persistence callback is configured
-  defp do_persist(token) when is_struct(token, AuthToken) do
+  # Persists an AuthToken via the configured callback, raising on failure.
+  defp persist!(token) when is_struct(token, AuthToken) do
     key = AuthToken.create_key(token)
 
-    case Config.lookup(__MODULE__, :persistence) do
-      {module, function, args} -> apply(module, function, [key, token | args])
-      {module, function} -> apply(module, function, [key, token])
-      _ -> nil
+    result =
+      case Config.lookup(__MODULE__, :persistence) do
+        {module, function, args} -> apply(module, function, [key, token | args])
+        {module, function} -> apply(module, function, [key, token])
+        _ -> :ok
+      end
+
+    case result do
+      {:error, reason} ->
+        raise ShopifyAPI.TokenPersistenceError,
+          message:
+            "Could not persist auth token for #{key}: " <>
+              "callback returned {:error, #{describe_reason(reason)}}"
+
+      _ ->
+        :ok
     end
   end
+
+  # Names the shape of a persistence failure but not its contents: a reason such as an Ecto
+  # changeset holds the token being written, and this message reaches logs and error trackers.
+  defp describe_reason(reason) when is_atom(reason), do: inspect(reason)
+  defp describe_reason(%module{}), do: "%#{inspect(module)}{}"
+  defp describe_reason(_reason), do: "_"
 end

--- a/lib/shopify_api/config.ex
+++ b/lib/shopify_api/config.ex
@@ -4,6 +4,11 @@ defmodule ShopifyAPI.Config do
   def lookup(key), do: Application.get_env(:shopify_api, key)
   def lookup(key, subkey), do: Application.get_env(:shopify_api, key)[subkey]
 
+  # Controls new token requests. Tokens that already carry a refresh token are refreshed
+  # regardless of this setting.
+  @spec expiring?() :: boolean()
+  def expiring?, do: Application.get_env(:shopify_api, :expiring, false) == true
+
   @spec app_name() :: String.t() | nil
   @spec app_name(Plug.Conn.t(), keyword()) :: String.t() | nil
   def app_name, do: lookup(:app_name)

--- a/lib/shopify_api/exception.ex
+++ b/lib/shopify_api/exception.ex
@@ -9,3 +9,19 @@ end
 defmodule ShopifyAPI.ShopAuthError do
   defexception message: "Invalid API key"
 end
+
+defmodule ShopifyAPI.TokenPersistenceError do
+  defexception message: "Auth token could not be persisted"
+end
+
+defmodule ShopifyAPI.TokenRefreshError do
+  @moduledoc """
+  Raised when refreshing an expiring offline token fails for any reason other than a dead
+  refresh token, such as Shopify erroring, timing out, or answering with an unusable pair.
+
+  The library treats these failures as transient, so Plug renders this exception as a `503`.
+  A dead refresh token does not raise: `ShopifyAPI.AuthToken.fetch/2` returns
+  `{:error, :needs_reacquisition}` for it.
+  """
+  defexception message: "Auth token could not be refreshed", plug_status: 503
+end

--- a/lib/shopify_api/jwt_session_token.ex
+++ b/lib/shopify_api/jwt_session_token.ex
@@ -22,10 +22,10 @@ defmodule ShopifyAPI.JWTSessionToken do
 
   ## Exchanging a session token
 
-  `get_offline_token/2` looks in `ShopifyAPI.AuthTokenServer` and exchanges on a miss.
-  `get_user_token/2` looks in `ShopifyAPI.UserTokenServer` with `get_valid/3`, so it also
-  exchanges when the cached token has expired. Both store what they receive, and neither
-  refreshes a token in place.
+  `get_offline_token/2` reads through `ShopifyAPI.AuthToken.fetch/2` and exchanges when no
+  usable token is found. `get_user_token/2` reads through
+  `ShopifyAPI.UserTokenServer.get_valid/3` and exchanges when the cached token has expired.
+  Both store what they receive.
 
   > #### The post-login hook runs unsupervised {: .warning}
   >
@@ -97,13 +97,16 @@ defmodule ShopifyAPI.JWTSessionToken do
     do: {:error, "Invalid user token or no id"}
 
   @doc """
-  Returns the shop's offline token, exchanging the session token for one if the cache has none.
+  Returns the shop's offline token, exchanging the session token for one if none is usable.
 
   Takes the decoded JWT and the raw token string it came from: the first names the shop and
-  app, the second is what Shopify wants as the subject of an exchange. A freshly exchanged
-  token is written to `ShopifyAPI.AuthTokenServer` by
-  `ShopifyAPI.AuthRequest.request_offline_access_token/3` before it is returned, and the
-  `post_login` hook fires.
+  app, the second is the subject of the exchange. A freshly exchanged token is written to
+  `ShopifyAPI.AuthTokenServer` before it is returned, and the `post_login` hook fires.
+
+  Reads through `ShopifyAPI.AuthToken.fetch/2`, so an expiring token is refreshed if needed.
+  When the refresh token itself is dead, the session token is exchanged for a new one — an
+  embedded app recovers without sending the merchant back through OAuth. Any other refresh
+  failure raises, as it does from `fetch/2`, rather than falling back to an exchange.
 
   This is the token-exchange equivalent of installing through `ShopifyAPI.Router`.
   """
@@ -114,12 +117,12 @@ defmodule ShopifyAPI.JWTSessionToken do
   def get_offline_token(%JOSE.JWT{} = jwt, token) do
     with {:ok, myshopify_domain} <- myshopify_domain(jwt),
          {:ok, app} <- app(jwt) do
-      case ShopifyAPI.AuthTokenServer.get(myshopify_domain, app.name) do
+      case ShopifyAPI.AuthToken.fetch(myshopify_domain, app.name) do
         {:ok, _} = resp ->
           resp
 
         {:error, _} ->
-          Logger.warning("No token found, exchanging for new")
+          Logger.warning("No usable token, exchanging session token for a new one")
 
           case ShopifyAPI.AuthRequest.request_offline_access_token(app, myshopify_domain, token) do
             {:ok, token} ->

--- a/lib/shopify_api/plugs/admin_authenticator.ex
+++ b/lib/shopify_api/plugs/admin_authenticator.ex
@@ -10,6 +10,11 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   The plug will assign the Shop, App and AuthToken to the Conn for easy access in your
   admin controller when the a valid hmac is provided.
 
+  The AuthToken is read through `ShopifyAPI.AuthToken.fetch/2`, so an expiring token is
+  refreshed if needed. A refresh that fails for a transient reason raises
+  `ShopifyAPI.TokenRefreshError`, which Plug renders as a `503`, rather than being treated as a
+  missing token.
+
   When no HMAC is provided, the plug passes through without assigning the Shop, App and AuthToken.
   Shopify expects this behaviour and has started rejecting new apps that do not behave this way.
 
@@ -84,7 +89,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
 
     with :ok <- validate_hmac(app, conn.query_params),
          {:ok, shop} <- ShopifyAPI.ShopServer.get_or_create(myshopify_domain, true),
-         {:ok, auth_token} <- ShopifyAPI.AuthTokenServer.get(myshopify_domain, app_name) do
+         {:ok, auth_token} <- ShopifyAPI.AuthToken.fetch(myshopify_domain, app_name) do
       conn
       |> assign_app(app)
       |> assign_shop(shop)

--- a/lib/shopify_api/plugs/auth_shop_session_token.ex
+++ b/lib/shopify_api/plugs/auth_shop_session_token.ex
@@ -2,6 +2,13 @@ defmodule ShopifyAPI.Plugs.AuthShopSessionToken do
   @moduledoc """
   A Plug to handle authenticating the Shop Admin JWT from Shopify.
 
+  The shop's offline token and the staff member's online token are read through
+  `ShopifyAPI.JWTSessionToken.get_offline_token/2` and
+  `ShopifyAPI.JWTSessionToken.get_user_token/2`, so the session token is exchanged for either
+  one when nothing usable is cached. Any other failure responds `401` and halts, except a
+  refresh that fails for a transient reason: that raises `ShopifyAPI.TokenRefreshError`, which
+  Plug renders as a `503`, so the frontend is not told its session is invalid.
+
   ## Example Installations
 
   Add this plug in a pipeline for your Shop Admin API.
@@ -18,7 +25,6 @@ defmodule ShopifyAPI.Plugs.AuthShopSessionToken do
 
   require Logger
 
-  alias ShopifyAPI.AuthTokenServer
   alias ShopifyAPI.JWTSessionToken
   alias ShopifyAPI.ShopServer
 
@@ -31,7 +37,7 @@ defmodule ShopifyAPI.Plugs.AuthShopSessionToken do
          {:ok, myshopify_domain} <- JWTSessionToken.myshopify_domain(jwt),
          {:ok, user_id} <- JWTSessionToken.user_id(jwt),
          {:ok, shop} <- ShopServer.get(myshopify_domain),
-         {:ok, auth_token} <- AuthTokenServer.get(myshopify_domain, app.name),
+         {:ok, auth_token} <- JWTSessionToken.get_offline_token(jwt, token),
          {:ok, user_token} <- JWTSessionToken.get_user_token(jwt, token) do
       conn
       |> assign(:app, app)

--- a/lib/shopify_api/refresh.ex
+++ b/lib/shopify_api/refresh.ex
@@ -1,0 +1,285 @@
+defmodule ShopifyAPI.Refresh do
+  @moduledoc """
+  Runs, schedules and de-duplicates refreshes of expiring offline access tokens.
+
+  Wraps `ShopifyAPI.AuthRequest.refresh_offline_access_token/2` with scheduling,
+  de-duplication and retry. `ShopifyAPI.AuthToken.fetch/2` is the usual caller.
+
+  ## Entry points
+
+    - `run/1` — synchronous, no retry, no de-duplication. The entry point for scheduled sweeps.
+    - `run_in_background/1` — returns immediately; refreshes in a supervised task with retries.
+      Skipped if one is already in flight for this shop and app.
+    - `await_or_run/1` — waits for a refresh already in flight, or runs one in the calling
+      process. Used when the token has expired and the caller needs a fresh one.
+
+  ## De-duplication
+
+  A per-node `Registry` tracks the background refresh in flight for each `{shop_name,
+  app_name}`. Only `run_in_background/1` registers; `await_or_run/1` checks the registry but
+  does not register when it falls through to refreshing itself, so multiple inline callers can
+  refresh concurrently. Concurrent refreshes of the same token are safe — Shopify returns the
+  same pair — so de-duplication is an optimisation, not a correctness requirement.
+
+  > #### Concurrent refresh behaviour is observed, not documented {: .warning}
+  >
+  > Shopify does not document that concurrent refreshes return the same pair. This was measured
+  > in CR-2679. Re-verify before the January 2027 cutover.
+
+  ## Failure
+
+  `{:error, :needs_reacquisition}` is returned (never retried) when the refresh token is dead.
+  All other failures (assumed to be transient) raise. `run_in_background/1` retries inside its task; `await_or_run/1`
+  and `run/1` do not — the caller's own retry (Oban, Phoenix) handles that.
+
+  ## Configuration
+
+      config :shopify_api,
+        refresh_threshold_seconds: 300,
+        refresh_wait_timeout_ms: :timer.seconds(2),
+        refresh_retry: [attempts: 3, backoff_ms: :timer.seconds(1)]
+
+  All three default to the values shown.
+
+    - `:refresh_threshold_seconds` — remaining token life, in seconds, below which `fetch/2`
+      starts a background refresh.
+    - `:refresh_wait_timeout_ms` — how long `await_or_run/1` waits on an in-flight refresh before
+      refreshing itself.
+    - `:refresh_retry` — `[attempts: n, backoff_ms: ms]` for background refreshes. Backoff is
+      exponential with full jitter.
+  """
+
+  require Logger
+
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.AuthRequest
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.AuthTokenServer
+
+  @registry ShopifyAPI.RefreshRegistry
+  @task_supervisor ShopifyAPI.RefreshTaskSupervisor
+
+  # 5 minutes
+  @default_threshold_seconds 300
+  @default_wait_timeout_ms :timer.seconds(2)
+  @default_retry [attempts: 3, backoff_ms: :timer.seconds(1)]
+
+  @doc """
+  Refreshes a token synchronously, without retrying.
+
+  Raises `ShopifyAPI.TokenRefreshError` on failure (assumed to be transient) and
+  `ShopifyAPI.TokenPersistenceError` if the new pair could not be stored.
+  """
+  @spec run(AuthToken.t()) :: AuthToken.ok_t() | AuthToken.needs_reacquisition()
+  def run(%AuthToken{refresh_token: nil} = token) do
+    raise ArgumentError,
+          "#{token.shop_name}:#{token.app_name} has no refresh token; it is a permanent token"
+  end
+
+  def run(%AuthToken{} = token) do
+    case AppServer.get(token.app_name) do
+      {:ok, app} ->
+        AuthRequest.refresh_offline_access_token(app, token)
+
+      :error ->
+        raise ArgumentError,
+              "#{token.app_name} is not a registered app, so #{token.shop_name} cannot refresh"
+    end
+  end
+
+  @doc """
+  Refreshes in the background, unless one is already running for this shop and app.
+
+  Returns `:ok` immediately. Failures surface as a crashed task.
+  """
+  @spec run_in_background(AuthToken.t()) :: :ok
+  def run_in_background(%AuthToken{} = token) do
+    Task.Supervisor.start_child(@task_supervisor, fn -> claim_and_refresh(token) end)
+    :ok
+  end
+
+  @doc """
+  Waits for a refresh already in flight, or runs one here if there is none.
+
+  Falls back to refreshing in the calling process when the wait exceeds
+  `:refresh_wait_timeout_ms`, or when the in-flight refresh finishes without producing a new
+  token.
+  """
+  @spec await_or_run(AuthToken.t()) :: AuthToken.ok_t() | AuthToken.needs_reacquisition()
+  def await_or_run(%AuthToken{} = token) do
+    case Registry.lookup(@registry, key(token)) do
+      [{pid, _value}] -> await(pid, token)
+      [] -> use_replacement_or_run(token)
+    end
+  end
+
+  @doc """
+  Remaining life below which `fetch/2` starts a background refresh, in milliseconds.
+
+  Read from `:refresh_threshold_seconds` (default #{@default_threshold_seconds}) and returned in
+  milliseconds to match `ShopifyAPI.AuthToken`'s remaining-life check.
+  """
+  @spec threshold() :: non_neg_integer()
+  def threshold do
+    :timer.seconds(
+      Application.get_env(:shopify_api, :refresh_threshold_seconds, @default_threshold_seconds)
+    )
+  end
+
+  @doc """
+  Returns cached expiring tokens whose pair is older than `age`.
+
+  Intended for a scheduled sweep. Tokens whose `token_expires_at` is further in the past than
+  `age` are included; tokens whose refresh token has already expired are excluded, since no
+  refresh can revive them.
+
+  Age is measured from `token_expires_at`, which Shopify sets one hour out on each refresh, so
+  it approximates the pair's issue time.
+
+  ## Examples
+
+      stale = ShopifyAPI.Refresh.shops_needing_refresh(Duration.new!(day: 28))
+      Enum.each(stale, &MyApp.RefreshWorker.enqueue(&1.shop_name))
+
+  """
+  @spec shops_needing_refresh(Duration.t()) :: [AuthToken.t()]
+  def shops_needing_refresh(%Duration{} = age) do
+    now = DateTime.utc_now()
+    issued_before = DateTime.shift(now, Duration.negate(age))
+
+    AuthTokenServer.all()
+    |> Map.values()
+    |> Enum.filter(&due?(&1, now, issued_before))
+  end
+
+  defp due?(%AuthToken{refresh_token: nil}, _now, _issued_before), do: false
+
+  defp due?(%AuthToken{} = token, now, issued_before) do
+    refreshable?(token.refresh_token_expires_at, now) and
+      older_than?(token.token_expires_at, issued_before)
+  end
+
+  # Past its own expiry the refresh token is dead, replay included.
+  defp refreshable?(nil, _now), do: true
+  defp refreshable?(%DateTime{} = expires_at, now), do: DateTime.after?(expires_at, now)
+
+  # Carries a refresh token but no access-token expiry to date it by. Refreshing repairs that.
+  defp older_than?(nil, _issued_before), do: true
+
+  defp older_than?(%DateTime{} = token_expires_at, issued_before),
+    do: DateTime.before?(token_expires_at, issued_before)
+
+  defp key(%AuthToken{shop_name: shop_name, app_name: app_name}), do: {shop_name, app_name}
+
+  # Registers as the in-flight refresh for this shop, then refreshes with retry.
+  defp claim_and_refresh(token) do
+    case Registry.register(@registry, key(token), :refreshing) do
+      {:ok, _pid} ->
+        Logger.debug("#{__MODULE__} refreshing #{AuthToken.create_key(token)} in the background")
+        with_retry(token, 1)
+
+      {:error, {:already_registered, _pid}} ->
+        Logger.debug("#{__MODULE__} refresh already in flight for #{AuthToken.create_key(token)}")
+        :ok
+    end
+  end
+
+  defp with_retry(token, attempt) do
+    run(token)
+  rescue
+    # Not a transient failure — do not retry.
+    error in ArgumentError ->
+      reraise error, __STACKTRACE__
+
+    # Includes a failed write. Shopify keeps the old refresh token live until its replacement is
+    # presented, and presenting it again returns the same pair (CR-2679), so a retry recovers the
+    # pair that could not be stored.
+    error ->
+      attempts = Keyword.get(retry_opts(), :attempts, 3)
+
+      if attempt < attempts do
+        Logger.debug(
+          "#{__MODULE__} refresh of #{AuthToken.create_key(token)} failed on attempt " <>
+            "#{attempt} of #{attempts}, backing off"
+        )
+
+        Process.sleep(backoff(attempt))
+
+        # Another caller may have refreshed this shop while we backed off.
+        if superseded?(token) do
+          Logger.debug(
+            "#{__MODULE__} #{AuthToken.create_key(token)} was refreshed elsewhere while " <>
+              "backing off, abandoning retry"
+          )
+
+          :ok
+        else
+          with_retry(token, attempt + 1)
+        end
+      else
+        Logger.error(
+          "#{__MODULE__} gave up refreshing #{token.shop_name}:#{token.app_name} after " <>
+            "#{attempts} attempts"
+        )
+
+        reraise error, __STACKTRACE__
+      end
+  end
+
+  defp superseded?(token) do
+    case AuthTokenServer.get(token.shop_name, token.app_name) do
+      {:ok, cached} -> cached.token != token.token
+      {:error, :not_found} -> false
+    end
+  end
+
+  # Exponential backoff with full jitter.
+  defp backoff(attempt) do
+    base = Keyword.get(retry_opts(), :backoff_ms, :timer.seconds(1))
+    :rand.uniform(max(base, 1) * 2 ** (attempt - 1))
+  end
+
+  defp retry_opts, do: Application.get_env(:shopify_api, :refresh_retry, @default_retry)
+
+  defp await(pid, token) do
+    ref = Process.monitor(pid)
+    Logger.debug("#{__MODULE__} waiting on refresh in flight for #{AuthToken.create_key(token)}")
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} ->
+        use_replacement_or_run(token)
+    after
+      wait_timeout() ->
+        Process.demonitor(ref, [:flush])
+
+        Logger.debug(
+          "#{__MODULE__} timed out waiting on refresh of #{AuthToken.create_key(token)}, " <>
+            "refreshing here instead"
+        )
+
+        use_replacement_or_run(token)
+    end
+  end
+
+  # Re-reads the cache before refreshing, in case another caller already refreshed this token.
+  defp use_replacement_or_run(token) do
+    case AuthTokenServer.get(token.shop_name, token.app_name) do
+      {:ok, cached} ->
+        if cached.token == token.token do
+          run(cached)
+        else
+          Logger.debug(
+            "#{__MODULE__} #{AuthToken.create_key(token)} was refreshed elsewhere, using that pair"
+          )
+
+          {:ok, cached}
+        end
+
+      {:error, :not_found} ->
+        run(token)
+    end
+  end
+
+  defp wait_timeout,
+    do: Application.get_env(:shopify_api, :refresh_wait_timeout_ms, @default_wait_timeout_ms)
+end

--- a/lib/shopify_api/refresh_supervisor.ex
+++ b/lib/shopify_api/refresh_supervisor.ex
@@ -1,0 +1,31 @@
+defmodule ShopifyAPI.RefreshSupervisor do
+  @moduledoc """
+  Supervises the processes that refresh expiring offline access tokens.
+
+  A separate subtree so that refresh failures (which come in bursts when Shopify is unwell)
+  do not exhaust the restart budget shared by the cache servers.
+
+  Two children, both idle until a refresh is requested:
+
+    - `ShopifyAPI.RefreshRegistry` — tracks the in-flight refresh per `{shop_name, app_name}`
+    - `ShopifyAPI.RefreshTaskSupervisor` — runs background refresh tasks (`:temporary`, never
+      restarted)
+
+  Starts unconditionally. The `:expiring` flag controls new token requests; whether a token
+  is refreshed depends on it carrying a refresh token.
+  """
+
+  use Supervisor
+
+  def start_link(_opts), do: Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl Supervisor
+  def init(:ok) do
+    children = [
+      {Registry, keys: :unique, name: ShopifyAPI.RefreshRegistry},
+      {Task.Supervisor, name: ShopifyAPI.RefreshTaskSupervisor}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/shopify_api/supervisor.ex
+++ b/lib/shopify_api/supervisor.ex
@@ -20,6 +20,7 @@ defmodule ShopifyAPI.Supervisor do
 
   alias ShopifyAPI.AppServer
   alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.RefreshSupervisor
   alias ShopifyAPI.ShopServer
   alias ShopifyAPI.UserTokenServer
 
@@ -29,7 +30,14 @@ defmodule ShopifyAPI.Supervisor do
 
   @impl Supervisor
   def init(:ok) do
-    children = [AppServer, AuthTokenServer, ShopServer, UserTokenServer]
+    children = [
+      AppServer,
+      AuthTokenServer,
+      ShopServer,
+      UserTokenServer,
+      RefreshSupervisor
+    ]
+
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/shopify_api/test.ex
+++ b/lib/shopify_api/test.ex
@@ -1,0 +1,118 @@
+defmodule ShopifyAPI.Test do
+  @moduledoc """
+  Builders for auth token states your tests need.
+
+  Each function returns a `ShopifyAPI.AuthToken` struct without touching the cache or Shopify.
+  Pass the result to `ShopifyAPI.AuthTokenServer.set/2` with `false` to populate the cache
+  without invoking your persistence callback.
+
+      token = ShopifyAPI.Test.expiring_token(shop_name: "shop.myshopify.com", app_name: "my-app")
+      ShopifyAPI.AuthTokenServer.set(token, false)
+
+  Three builders cover the token lifecycle:
+
+    - `expiring_token/1` — live, both expiries in the future
+    - `expired_token/1` — access token expired, refresh token alive (triggers a refresh)
+    - `dead_token/1` — both halves expired (returns `{:error, :needs_reacquisition}`)
+
+  A bare `%ShopifyAPI.AuthToken{}` has `refresh_token: nil`, so it behaves as a permanent
+  token that is never refreshed.
+  """
+
+  alias ShopifyAPI.AuthToken
+
+  @ninety_days :timer.hours(24 * 90)
+
+  @doc """
+  Builds a live expiring token with both expiries in the future.
+
+  `ShopifyAPI.AuthToken.fetch/2` returns it without refreshing. Any field can be overridden
+  through `attrs`.
+
+  ## Examples
+
+      iex> token = ShopifyAPI.Test.expiring_token(shop_name: "live.myshopify.com", app_name: "my-app")
+      iex> ShopifyAPI.AuthTokenServer.set(token, false)
+      iex> ShopifyAPI.AuthToken.fetch("live.myshopify.com", "my-app")
+      {:ok, token}
+
+  """
+  @spec expiring_token(keyword()) :: AuthToken.t()
+  def expiring_token(attrs \\ []) do
+    build(
+      [
+        token_expires_at: from_now(:timer.minutes(55)),
+        refresh_token: "shprt_test_refresh_token",
+        refresh_token_expires_at: from_now(@ninety_days)
+      ],
+      attrs
+    )
+  end
+
+  @doc """
+  Builds an expiring token whose access token has expired but whose refresh token has not.
+
+  `ShopifyAPI.AuthToken.fetch/2` will refresh before returning, so tests using this need
+  Shopify's token endpoint stubbed and the app registered in `ShopifyAPI.AppServer`.
+
+  ## Examples
+
+      iex> token = ShopifyAPI.Test.expired_token()
+      iex> DateTime.after?(DateTime.utc_now(), token.token_expires_at)
+      true
+      iex> DateTime.after?(token.refresh_token_expires_at, DateTime.utc_now())
+      true
+
+  """
+  @spec expired_token(keyword()) :: AuthToken.t()
+  def expired_token(attrs \\ []) do
+    build(
+      [
+        token_expires_at: from_now(-:timer.minutes(5)),
+        refresh_token: "shprt_test_refresh_token",
+        refresh_token_expires_at: from_now(@ninety_days)
+      ],
+      attrs
+    )
+  end
+
+  @doc """
+  Builds an expiring token where both halves have expired.
+
+  `ShopifyAPI.AuthToken.fetch/2` returns `{:error, :needs_reacquisition}` without calling
+  Shopify.
+
+  ## Examples
+
+      iex> token = ShopifyAPI.Test.dead_token(shop_name: "lapsed.myshopify.com", app_name: "my-app")
+      iex> ShopifyAPI.AuthTokenServer.set(token, false)
+      iex> ShopifyAPI.AuthToken.fetch("lapsed.myshopify.com", "my-app")
+      {:error, :needs_reacquisition}
+
+  """
+  @spec dead_token(keyword()) :: AuthToken.t()
+  def dead_token(attrs \\ []) do
+    build(
+      [
+        token_expires_at: from_now(-@ninety_days),
+        refresh_token: "shprt_test_refresh_token",
+        refresh_token_expires_at: from_now(-:timer.hours(1))
+      ],
+      attrs
+    )
+  end
+
+  defp build(defaults, attrs) do
+    struct!(
+      %AuthToken{
+        shop_name: "test-shop.myshopify.com",
+        app_name: "test-app",
+        token: "shpat_test_access_token"
+      },
+      Keyword.merge(defaults, attrs)
+    )
+  end
+
+  defp from_now(milliseconds),
+    do: DateTime.add(DateTime.utc_now(), milliseconds, :millisecond)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,11 @@ defmodule Plug.ShopifyAPI.MixProject do
           ShopifyAPI.UserTokenServer,
           ShopifyAPI.Supervisor
         ],
+        "Token Refresh": [
+          ShopifyAPI.Refresh,
+          ShopifyAPI.RefreshSupervisor
+        ],
+        Testing: [ShopifyAPI.Test],
         Plugs: [~r/^ShopifyAPI\.Plugs\./],
         REST: [~r/^ShopifyAPI\.REST/],
         GraphQL: [~r/^ShopifyAPI\.GraphQL/, ~r/^ShopifyAPI\.Bulk/],

--- a/test/shopify_api/auth_request_test.exs
+++ b/test/shopify_api/auth_request_test.exs
@@ -1,0 +1,155 @@
+defmodule ShopifyAPI.AuthRequestTest do
+  # Not async: swaps the top-level :expiring setting, which is global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Plug.Conn
+  alias ShopifyAPI.App
+  alias ShopifyAPI.AuthRequest
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.JSONSerializer
+
+  # The app cache is shared across the suite and `AppServer.get_by_client_id/1` matches a single
+  # app, so every test module needs a client id of its own.
+  @app %App{
+    name: "acquisition-test-app",
+    client_id: "acquisition-client-id",
+    client_secret: "client-secret"
+  }
+
+  setup do
+    previous = Application.get_env(:shopify_api, :expiring)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:shopify_api, :expiring, previous)
+      else
+        Application.delete_env(:shopify_api, :expiring)
+      end
+    end)
+
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, shop: "localhost:#{bypass.port}"}
+  end
+
+  @pair %{
+    access_token: "shpat_acquired",
+    expires_in: 3600,
+    refresh_token: "shprt_acquired",
+    refresh_token_expires_in: 7_775_999
+  }
+
+  # Captures the JSON body the library posted to the token endpoint.
+  defp capture_body(bypass, response \\ @pair) do
+    test_pid = self()
+
+    Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+      {:ok, body, conn} = Conn.read_body(conn)
+      send(test_pid, {:body, JSONSerializer.decode!(body)})
+
+      Conn.resp(conn, 200, JSONSerializer.encode!(response))
+    end)
+  end
+
+  describe "expiring: 1 on acquisition" do
+    test "the auth code grant asks for an expiring token when configured", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      Application.put_env(:shopify_api, :expiring, true)
+      capture_body(bypass)
+
+      AuthRequest.post(@app, shop, "auth-code")
+
+      assert_receive {:body, body}
+      assert body["expiring"] == 1
+    end
+
+    test "the auth code grant asks for a permanent token when not configured", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      Application.put_env(:shopify_api, :expiring, false)
+      capture_body(bypass)
+
+      AuthRequest.post(@app, shop, "auth-code")
+
+      assert_receive {:body, body}
+      refute Map.has_key?(body, "expiring")
+    end
+
+    test "token exchange asks for an expiring token when configured", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      Application.put_env(:shopify_api, :expiring, true)
+      capture_body(bypass)
+
+      AuthRequest.request_offline_access_token(@app, shop, "session-token")
+
+      assert_receive {:body, body}
+      assert body["expiring"] == 1
+      assert body["requested_token_type"] =~ "offline-access-token"
+    end
+
+    test "the OAuth code grant parses the pair out of the response", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      # App.fetch_token/3 is called from the OAuth redirect and must parse the full pair.
+      Application.put_env(:shopify_api, :expiring, true)
+      capture_body(bypass)
+
+      assert {:ok, token} = ShopifyAPI.App.fetch_token(@app, shop, "auth-code")
+
+      assert token.token == "shpat_acquired"
+      assert token.refresh_token == "shprt_acquired"
+      assert DateTime.after?(token.token_expires_at, DateTime.utc_now())
+      assert DateTime.after?(token.refresh_token_expires_at, token.token_expires_at)
+    end
+
+    test "a refresh never asks, whatever the setting", %{bypass: bypass, shop: shop} do
+      # Shopify does not accept `expiring` on a refresh grant.
+      Application.put_env(:shopify_api, :expiring, true)
+      capture_body(bypass)
+
+      token =
+        ShopifyAPI.Test.expiring_token(shop_name: shop, app_name: @app.name)
+
+      AuthRequest.refresh_offline_access_token(@app, token)
+
+      assert_receive {:body, body}
+      refute Map.has_key?(body, "expiring")
+      assert body["grant_type"] == "refresh_token"
+    end
+  end
+
+  describe "acquisition rejects an unusable pair" do
+    test "token exchange stores nothing when part of the pair is missing", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      capture_body(bypass, Map.delete(@pair, :refresh_token))
+
+      log =
+        capture_log(fn ->
+          assert {:error, :failed_fetching_offline_token} =
+                   AuthRequest.request_offline_access_token(@app, shop, "session-token")
+        end)
+
+      assert {:error, :not_found} = AuthTokenServer.get(shop, @app.name)
+      # The log names the problem, never the response body, which carries the credentials.
+      assert log =~ "incomplete_pair"
+      refute log =~ "shpat_acquired"
+    end
+
+    test "the OAuth code grant rejects an incomplete pair", %{bypass: bypass, shop: shop} do
+      capture_body(bypass, Map.delete(@pair, :refresh_token))
+
+      capture_log(fn ->
+        assert {:error, _} = App.fetch_token(@app, shop, "auth-code")
+      end)
+    end
+  end
+end

--- a/test/shopify_api/auth_token_fetch_test.exs
+++ b/test/shopify_api/auth_token_fetch_test.exs
@@ -1,0 +1,376 @@
+defmodule ShopifyAPI.AuthTokenFetchTest do
+  # Not async: shares the public token cache and a Bypass port with no other test.
+  use ExUnit.Case, async: false
+
+  alias Plug.Conn
+  alias ShopifyAPI.App
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.JSONSerializer
+  alias ShopifyAPI.TokenRefreshError
+
+  @app_name "fetch-test-app"
+  @hour :timer.hours(1)
+  @ninety_days 7_775_999
+
+  setup do
+    AppServer.set(%App{name: @app_name, client_id: "client-id", client_secret: "client-secret"})
+
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, shop: "localhost:#{bypass.port}"}
+  end
+
+  defp cache(shop, attrs) do
+    token =
+      struct!(
+        %AuthToken{shop_name: shop, app_name: @app_name, token: "shpat_current"},
+        attrs
+      )
+
+    AuthTokenServer.set(token, false)
+    token
+  end
+
+  defp from_now(milliseconds),
+    do: DateTime.add(DateTime.utc_now(), milliseconds, :millisecond)
+
+  defp respond_with_pair(bypass, body) do
+    test_pid = self()
+
+    Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+      send(test_pid, :refresh_requested)
+      Conn.resp(conn, 200, JSONSerializer.encode!(body))
+    end)
+  end
+
+  defp fresh_pair do
+    %{
+      access_token: "shpat_refreshed",
+      expires_in: 3600,
+      refresh_token: "shprt_refreshed",
+      refresh_token_expires_in: @ninety_days
+    }
+  end
+
+  describe "cache misses and permanent tokens" do
+    test "reports a shop with nothing cached as not found" do
+      assert {:error, :not_found} = AuthToken.fetch("never-installed.myshopify.com", @app_name)
+    end
+
+    test "returns a permanent token untouched", %{shop: shop} do
+      token = cache(shop, token_expires_at: nil, refresh_token: nil)
+
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+    end
+
+    test "ignores a stale expiry on a permanent token", %{shop: shop} do
+      # A nil refresh token settles it before any expiry is consulted.
+      token = cache(shop, token_expires_at: from_now(-@hour), refresh_token: nil)
+
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+    end
+  end
+
+  describe "expiring tokens with life left" do
+    test "returns a comfortably live token without refreshing", %{shop: shop} do
+      token =
+        cache(shop,
+          token_expires_at: from_now(@hour),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+      refute_receive :refresh_requested, 100
+    end
+
+    test "keeps serving a token inside the threshold whose refresh token has died", %{shop: shop} do
+      # Inside the threshold but the refresh token is dead. The access token still works, so
+      # it is served without attempting a refresh. `status/2` agrees.
+      token =
+        cache(shop,
+          token_expires_at: from_now(:timer.minutes(4)),
+          refresh_token: "shprt_dead",
+          refresh_token_expires_at: from_now(-@hour)
+        )
+
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+      assert :ok = AuthToken.status(shop, @app_name)
+      refute_receive :refresh_requested, 100
+    end
+
+    test "keeps serving a live access token whose refresh token has died", %{shop: shop} do
+      # A dead refresh token is only fatal once the access token has also expired.
+      token =
+        cache(shop,
+          token_expires_at: from_now(@hour),
+          refresh_token: "shprt_dead",
+          refresh_token_expires_at: from_now(-@hour)
+        )
+
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+    end
+  end
+
+  describe "reacquisition" do
+    test "reports a spent access token with a dead refresh token", %{shop: shop} do
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_dead",
+        refresh_token_expires_at: from_now(-@hour)
+      )
+
+      assert {:error, :needs_reacquisition} = AuthToken.fetch(shop, @app_name)
+      refute_receive :refresh_requested, 100
+    end
+  end
+
+  describe "background refresh" do
+    test "returns the current token and refreshes out of band", %{bypass: bypass, shop: shop} do
+      respond_with_pair(bypass, fresh_pair())
+
+      token =
+        cache(shop,
+          # Inside the default five-minute threshold, but not yet expired.
+          token_expires_at: from_now(:timer.minutes(2)),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      # The caller is handed what it already had rather than waiting.
+      assert {:ok, ^token} = AuthToken.fetch(shop, @app_name)
+
+      assert_receive :refresh_requested, 1_000
+      assert eventually_cached(shop, "shpat_refreshed")
+    end
+  end
+
+  describe "synchronous refresh" do
+    test "refreshes an expired token before returning it", %{bypass: bypass, shop: shop} do
+      respond_with_pair(bypass, fresh_pair())
+
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_current",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert {:ok, refreshed} = AuthToken.fetch(shop, @app_name)
+      assert refreshed.token == "shpat_refreshed"
+      assert refreshed.refresh_token == "shprt_refreshed"
+      assert DateTime.after?(refreshed.token_expires_at, DateTime.utc_now())
+    end
+
+    test "keeps what a refresh response does not describe", %{bypass: bypass, shop: shop} do
+      # A refresh response carries credentials but not shop metadata like `plus`.
+      respond_with_pair(bypass, fresh_pair())
+
+      cache(shop,
+        plus: true,
+        timestamp: 1_600_000_000,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_current",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert {:ok, refreshed} = AuthToken.fetch(shop, @app_name)
+      assert refreshed.token == "shpat_refreshed"
+      assert refreshed.plus
+      assert refreshed.timestamp == 1_600_000_000
+    end
+
+    test "reports reacquisition when Shopify rejects the refresh token", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        Conn.resp(conn, 401, ~s({"error":"invalid_request"}))
+      end)
+
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_superseded",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert {:error, :needs_reacquisition} = AuthToken.fetch(shop, @app_name)
+    end
+
+    test "raises on a transient Shopify failure", %{bypass: bypass, shop: shop} do
+      Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        Conn.resp(conn, 503, "")
+      end)
+
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_current",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert_raise TokenRefreshError, fn -> AuthToken.fetch(shop, @app_name) end
+    end
+
+    test "refuses a pair whose refresh token expires no later than its access token", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      # Observed from Shopify in July 2026. The pair is rejected because persisting it would
+      # leave the shop unrefreshable once the access token expires.
+      respond_with_pair(bypass, %{fresh_pair() | refresh_token_expires_in: 3599})
+
+      original =
+        cache(shop,
+          token_expires_at: from_now(-@hour),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      assert_raise TokenRefreshError, ~r/no later than/, fn ->
+        AuthToken.fetch(shop, @app_name)
+      end
+
+      assert {:ok, ^original} = AuthTokenServer.get(shop, @app_name)
+    end
+
+    test "refuses a refresh response missing part of the pair", %{bypass: bypass, shop: shop} do
+      # A refresh always returns a complete rotating pair; a response missing any of the four
+      # fields is rejected rather than cached as a token with nil expiries.
+      respond_with_pair(bypass, Map.delete(fresh_pair(), :refresh_token_expires_in))
+
+      original =
+        cache(shop,
+          token_expires_at: from_now(-@hour),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      assert_raise TokenRefreshError, ~r/incomplete pair/, fn ->
+        AuthToken.fetch(shop, @app_name)
+      end
+
+      assert {:ok, ^original} = AuthTokenServer.get(shop, @app_name)
+    end
+
+    test "refuses a refresh response that is not JSON", %{bypass: bypass, shop: shop} do
+      # A truncated body can still carry credentials, so the error names the problem without
+      # quoting the body.
+      Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        Conn.resp(conn, 200, ~s({"access_token":"shpat_refreshed","expires_in":))
+      end)
+
+      original =
+        cache(shop,
+          token_expires_at: from_now(-@hour),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      error =
+        assert_raise TokenRefreshError, ~r/not JSON/, fn ->
+          AuthToken.fetch(shop, @app_name)
+        end
+
+      refute error.message =~ "shpat_refreshed"
+      assert {:ok, ^original} = AuthTokenServer.get(shop, @app_name)
+    end
+  end
+
+  describe "JWTSessionToken.get_offline_token/2" do
+    # `myshopify_domain/1` keeps only the host of the `dest` claim, so a Bypass `localhost:port`
+    # shop name cannot survive the round trip. These key on a bare host instead, which is also
+    # why the exchange below is asserted on reaching Shopify rather than on its result.
+    defp jwt_for(domain),
+      do: %JOSE.JWT{fields: %{"dest" => "https://#{domain}", "aud" => "client-id"}}
+
+    test "exchanges rather than handing back a dead cached token" do
+      # A bare cache read would return the dead token. `get_offline_token/2` must detect that
+      # and fall through to an exchange instead.
+      cache("localhost",
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_dead",
+        refresh_token_expires_at: from_now(-@hour)
+      )
+
+      # Nothing listens on the default port, so the exchange fails immediately. That failure is
+      # the assertion: reaching an exchange at all proves the dead token was not handed back.
+      assert {:error, :failed_fetching_offline_token} =
+               ShopifyAPI.JWTSessionToken.get_offline_token(jwt_for("localhost"), "session-token")
+    end
+
+    test "raises rather than exchanging when a refresh fails" do
+      # The refresh goes to localhost too, where nothing answers it with a pair. That is a
+      # transient failure, not a rejected refresh token, so it must not fall through to an
+      # exchange, which would return an error rather than raise.
+      cache("localhost",
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_current",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert_raise TokenRefreshError, fn ->
+        ShopifyAPI.JWTSessionToken.get_offline_token(jwt_for("localhost"), "session-token")
+      end
+    end
+
+    test "returns a live cached token without exchanging" do
+      domain = "jwt-live.myshopify.com"
+
+      token =
+        cache(domain,
+          token_expires_at: from_now(@hour),
+          refresh_token: "shprt_current",
+          refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+        )
+
+      # Getting the cached struct back unchanged is the proof: an exchange would have replaced
+      # it, and there is nothing for one to succeed against here.
+      assert {:ok, ^token} =
+               ShopifyAPI.JWTSessionToken.get_offline_token(jwt_for(domain), "session-token")
+    end
+  end
+
+  describe "status/2" do
+    test "calls an expired but refreshable token usable", %{shop: shop} do
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_current",
+        refresh_token_expires_at: from_now(:timer.hours(24 * 90))
+      )
+
+      assert :ok = AuthToken.status(shop, @app_name)
+      # Does not contact Shopify.
+      refute_receive :refresh_requested, 100
+    end
+
+    test "calls a token past reviving needs_reacquisition", %{shop: shop} do
+      cache(shop,
+        token_expires_at: from_now(-@hour),
+        refresh_token: "shprt_dead",
+        refresh_token_expires_at: from_now(-@hour)
+      )
+
+      assert :needs_reacquisition = AuthToken.status(shop, @app_name)
+    end
+
+    test "calls a permanent token usable", %{shop: shop} do
+      cache(shop, refresh_token: nil, token_expires_at: nil)
+
+      assert :ok = AuthToken.status(shop, @app_name)
+    end
+  end
+
+  defp eventually_cached(shop, expected_token, attempts \\ 50) do
+    case AuthTokenServer.get(shop, @app_name) do
+      {:ok, %AuthToken{token: ^expected_token}} ->
+        true
+
+      _ when attempts > 0 ->
+        Process.sleep(20)
+        eventually_cached(shop, expected_token, attempts - 1)
+
+      _ ->
+        false
+    end
+  end
+end

--- a/test/shopify_api/auth_token_server_test.exs
+++ b/test/shopify_api/auth_token_server_test.exs
@@ -1,8 +1,127 @@
 defmodule ShopifyAPI.AuthTokenServerTest do
-  use ExUnit.Case, async: true
+  # Not async: the persistence tests swap the callback in application env, which is global.
+  use ExUnit.Case, async: false
+
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.TokenPersistenceError
 
   # The ETS table is public and shared across the whole suite, so each example keys its tokens
   # on a shop and app pair that no other example or test uses. The rest of the suite builds
   # shop names with Faker, so the plain names in the docs cannot collide with them.
   doctest ShopifyAPI.AuthTokenServer
+
+  defmodule PersistenceDouble do
+    @moduledoc false
+
+    alias ShopifyAPI.AuthToken
+
+    def save(_key, %AuthToken{shop_name: "raising.myshopify.com"}),
+      do: raise(ArgumentError, "storage is down")
+
+    def save(_key, %AuthToken{shop_name: "erroring.myshopify.com"}), do: {:error, :db_unavailable}
+    def save(_key, %AuthToken{shop_name: "nil-returning.myshopify.com"}), do: nil
+
+    # Shaped like an `{:error, changeset}`, whose changes carry the token being written.
+    def save(_key, %AuthToken{shop_name: "rejecting.myshopify.com"} = token),
+      do: {:error, %{changes: %{token: token.token}}}
+
+    # The callback runs in the calling process, so this reaches the test.
+    def save(key, token) do
+      send(self(), {:persisted, key, token})
+      :ok
+    end
+  end
+
+  setup do
+    previous = Application.get_env(:shopify_api, AuthTokenServer)
+
+    Application.put_env(:shopify_api, AuthTokenServer,
+      persistence: {PersistenceDouble, :save, []}
+    )
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:shopify_api, AuthTokenServer, previous)
+      else
+        Application.delete_env(:shopify_api, AuthTokenServer)
+      end
+    end)
+
+    :ok
+  end
+
+  defp token(shop_name, attrs \\ []) do
+    struct!(
+      %AuthToken{shop_name: shop_name, app_name: "persistence-test-app", token: "shpat_abc"},
+      attrs
+    )
+  end
+
+  describe "set/2 persistence" do
+    test "calls the callback with the string key and the token" do
+      token = token("persists.myshopify.com")
+
+      assert :ok = AuthTokenServer.set(token)
+      assert_received {:persisted, "persists.myshopify.com:persistence-test-app", ^token}
+    end
+
+    test "skips the callback when told not to persist" do
+      assert :ok = AuthTokenServer.set(token("unpersisted.myshopify.com"), false)
+      refute_received {:persisted, _, _}
+    end
+
+    test "treats a nil return as success" do
+      assert :ok = AuthTokenServer.set(token("nil-returning.myshopify.com"))
+      assert {:ok, _} = AuthTokenServer.get("nil-returning.myshopify.com", "persistence-test-app")
+    end
+
+    test "raises when the callback returns an error tuple" do
+      assert_raise TokenPersistenceError, ~r/db_unavailable/, fn ->
+        AuthTokenServer.set(token("erroring.myshopify.com"))
+      end
+    end
+
+    test "keeps the error reason's contents out of the message" do
+      error =
+        assert_raise TokenPersistenceError, fn ->
+          AuthTokenServer.set(token("rejecting.myshopify.com"))
+        end
+
+      refute error.message =~ "shpat_abc"
+    end
+
+    test "lets an exception from the callback propagate" do
+      assert_raise ArgumentError, "storage is down", fn ->
+        AuthTokenServer.set(token("raising.myshopify.com"))
+      end
+    end
+  end
+
+  describe "set/2 write ordering" do
+    # A failed persist must not update the cache — both sides stay on the old pair.
+    test "leaves the cached token untouched when persistence errors" do
+      original = token("erroring.myshopify.com", refresh_token: "shprt_original")
+      AuthTokenServer.set(original, false)
+
+      assert_raise TokenPersistenceError, fn ->
+        AuthTokenServer.set(token("erroring.myshopify.com", refresh_token: "shprt_replacement"))
+      end
+
+      assert {:ok, ^original} =
+               AuthTokenServer.get("erroring.myshopify.com", "persistence-test-app")
+    end
+
+    test "leaves the cached token untouched when the callback raises" do
+      original = token("raising.myshopify.com", refresh_token: "shprt_original")
+      AuthTokenServer.set(original, false)
+
+      assert_raise ArgumentError, fn ->
+        AuthTokenServer.set(token("raising.myshopify.com", refresh_token: "shprt_replacement"))
+      end
+
+      assert {:ok, ^original} =
+               AuthTokenServer.get("raising.myshopify.com", "persistence-test-app")
+    end
+  end
 end

--- a/test/shopify_api/auth_token_test.exs
+++ b/test/shopify_api/auth_token_test.exs
@@ -1,0 +1,189 @@
+defmodule ShopifyAPI.AuthTokenTest do
+  use ExUnit.Case, async: true
+
+  alias ShopifyAPI.App
+  alias ShopifyAPI.AuthToken
+
+  doctest ShopifyAPI.AuthToken
+  # ShopifyAPI.Test builds AuthToken states, so its builder doctests run here.
+  doctest ShopifyAPI.Test
+
+  @app %App{name: "my-app"}
+
+  # A complete expiring pair. validate_pair/1 compares the two expiries with each other, never
+  # with the clock, so fixed instants keep its examples exact.
+  @pair %AuthToken{
+    token_expires_at: ~U[2026-09-11 13:00:00Z],
+    refresh_token: "shprt_xyz",
+    refresh_token_expires_at: ~U[2026-12-10 13:00:00Z]
+  }
+
+  describe "from_auth_request/4" do
+    test "derives both expiries from the response durations" do
+      attrs = %{
+        "access_token" => "shpat_abc",
+        "expires_in" => 3600,
+        "refresh_token" => "shprt_xyz",
+        "refresh_token_expires_in" => 7_775_999
+      }
+
+      before = DateTime.utc_now()
+      token = AuthToken.from_auth_request(@app, "shop.myshopify.com", attrs)
+
+      assert_in_delta DateTime.diff(token.token_expires_at, before), 3600, 2
+      assert_in_delta DateTime.diff(token.refresh_token_expires_at, before), 7_775_999, 2
+    end
+
+    test "leaves the expiring fields nil for a permanent token" do
+      token =
+        AuthToken.from_auth_request(@app, "shop.myshopify.com", %{"access_token" => "shpat"})
+
+      assert token.refresh_token == nil
+      assert token.token_expires_at == nil
+      assert token.refresh_token_expires_at == nil
+    end
+
+    test "writes a replayed response's partly-spent countdown honestly" do
+      # A replay returns the original pair with its countdown already running down, so a
+      # short expires_in must be taken at face value rather than treated as a fresh hour.
+      attrs = %{
+        "access_token" => "shpat_abc",
+        "expires_in" => 12,
+        "refresh_token" => "shprt_xyz",
+        "refresh_token_expires_in" => 7_775_999
+      }
+
+      before = DateTime.utc_now()
+      token = AuthToken.from_auth_request(@app, "shop.myshopify.com", attrs)
+
+      assert_in_delta DateTime.diff(token.token_expires_at, before), 12, 2
+    end
+  end
+
+  describe "validate_pair/1" do
+    test "accepts a permanent token, which carries none of the expiring fields" do
+      assert :ok = AuthToken.validate_pair(%AuthToken{})
+    end
+
+    test "accepts a complete pair whose refresh token outlives its access token" do
+      assert :ok = AuthToken.validate_pair(@pair)
+    end
+
+    for {label, access_token} <- [missing: nil, "not a string": 12_345] do
+      test "rejects a permanent token whose access token is #{label}" do
+        token = %AuthToken{token: unquote(access_token)}
+
+        assert {:error, :incomplete_pair} = AuthToken.validate_pair(token)
+      end
+
+      test "rejects an expiring token whose access token is #{label}" do
+        token = %{@pair | token: unquote(access_token)}
+
+        assert {:error, :incomplete_pair} = AuthToken.validate_pair(token)
+      end
+    end
+
+    # Every mix of set and unset fields short of all three or none.
+    for present <- [
+          [:token_expires_at],
+          [:refresh_token],
+          [:refresh_token_expires_at],
+          [:token_expires_at, :refresh_token],
+          [:token_expires_at, :refresh_token_expires_at],
+          [:refresh_token, :refresh_token_expires_at]
+        ] do
+      test "rejects a token with only #{Enum.join(present, " and ")} set" do
+        token = struct!(AuthToken, Map.take(Map.from_struct(@pair), unquote(present)))
+
+        assert {:error, :incomplete_pair} = AuthToken.validate_pair(token)
+      end
+    end
+
+    test "rejects a refresh token that is not a string" do
+      token = %{@pair | refresh_token: 12_345}
+
+      assert {:error, :incomplete_pair} = AuthToken.validate_pair(token)
+    end
+
+    test "rejects expiries that are not DateTimes" do
+      token = %{@pair | token_expires_at: 3600, refresh_token_expires_at: 7_775_999}
+
+      assert {:error, :incomplete_pair} = AuthToken.validate_pair(token)
+    end
+
+    test "rejects a refresh token that expires before its access token" do
+      token = %{@pair | refresh_token_expires_at: ~U[2026-09-11 12:59:59Z]}
+
+      assert {:error, :refresh_token_expires_first} = AuthToken.validate_pair(token)
+    end
+  end
+
+  describe "refresh_outlives_access?/1" do
+    test "is true when the refresh token expires after the access token" do
+      assert AuthToken.refresh_outlives_access?(@pair)
+    end
+
+    test "is false when both expire at the same instant" do
+      token = %{@pair | refresh_token_expires_at: @pair.token_expires_at}
+
+      refute AuthToken.refresh_outlives_access?(token)
+    end
+
+    test "is false when the refresh token expires first" do
+      token = %{@pair | refresh_token_expires_at: ~U[2026-09-11 12:59:59Z]}
+
+      refute AuthToken.refresh_outlives_access?(token)
+    end
+
+    test "is false for a permanent token" do
+      refute AuthToken.refresh_outlives_access?(%AuthToken{})
+    end
+
+    test "is false without an access token expiry" do
+      refute AuthToken.refresh_outlives_access?(%{@pair | token_expires_at: nil})
+    end
+
+    test "is false without a refresh token expiry" do
+      refute AuthToken.refresh_outlives_access?(%{@pair | refresh_token_expires_at: nil})
+    end
+  end
+
+  describe "serialization" do
+    test "round-trips the expiring fields through Jason" do
+      attrs = %{
+        "access_token" => "shpat_abc",
+        "expires_in" => 3600,
+        "refresh_token" => "shprt_xyz",
+        "refresh_token_expires_in" => 7_775_999
+      }
+
+      encoded =
+        @app
+        |> AuthToken.from_auth_request("shop.myshopify.com", attrs)
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert encoded["refresh_token"] == "shprt_xyz"
+      assert encoded["token_expires_at"]
+      assert encoded["refresh_token_expires_at"]
+    end
+
+    test "keeps secrets out of inspect output" do
+      attrs = %{
+        "access_token" => "shpat_secret",
+        "refresh_token" => "shprt_secret",
+        "expires_in" => 3600
+      }
+
+      inspected =
+        @app
+        |> AuthToken.from_auth_request("shop.myshopify.com", "auth-code-secret", attrs)
+        |> inspect()
+
+      refute inspected =~ "shpat_secret"
+      refute inspected =~ "shprt_secret"
+      refute inspected =~ "auth-code-secret"
+      assert inspected =~ "shop.myshopify.com"
+    end
+  end
+end

--- a/test/shopify_api/exception_test.exs
+++ b/test/shopify_api/exception_test.exs
@@ -1,0 +1,13 @@
+defmodule ShopifyAPI.ExceptionTest do
+  use ExUnit.Case, async: true
+
+  describe "Plug status" do
+    test "a failed refresh renders as 503, since it is assumed to be transient" do
+      assert Plug.Exception.status(%ShopifyAPI.TokenRefreshError{}) == 503
+    end
+
+    test "a failed write renders as 500, since it is the app's own fault" do
+      assert Plug.Exception.status(%ShopifyAPI.TokenPersistenceError{}) == 500
+    end
+  end
+end

--- a/test/shopify_api/plugs/admin_authenticator_test.exs
+++ b/test/shopify_api/plugs/admin_authenticator_test.exs
@@ -6,7 +6,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticatorTest do
   import ShopifyAPI.SessionTokenSetup
 
   alias Plug.Conn
-  alias ShopifyAPI.{AppServer, ShopServer}
+  alias ShopifyAPI.{AppServer, AuthTokenServer, ShopServer}
   alias ShopifyAPI.Plugs.AdminAuthenticator
   alias ShopifyAPI.ShopifyValidationSetup
 
@@ -82,6 +82,36 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticatorTest do
       assert conn.assigns.shop == shop
       assert conn.assigns.auth_token == offline_token
       assert conn.assigns.user_token == online_token
+    end
+  end
+
+  describe "with a valid hmac and no session token" do
+    test "raises rather than redirecting to OAuth when a refresh fails", %{app: app} do
+      # Shopify erroring on the refresh is transient. Treating it as a missing token would send
+      # the merchant back through install.
+      bypass = Bypass.open()
+      shop = "localhost:#{bypass.port}"
+
+      Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        Conn.resp(conn, 503, "")
+      end)
+
+      AuthTokenServer.set(
+        ShopifyAPI.Test.expired_token(shop_name: shop, app_name: app.name),
+        false
+      )
+
+      params = ShopifyValidationSetup.params_append_hmac(app, %{shop: shop})
+
+      conn =
+        :get
+        |> conn("/admin/#{app.name}?" <> URI.encode_query(params))
+        |> init_test_session(%{})
+        |> Conn.fetch_query_params()
+
+      assert_raise ShopifyAPI.TokenRefreshError, fn ->
+        AdminAuthenticator.call(conn, app_name: app.name)
+      end
     end
   end
 

--- a/test/shopify_api/plugs/auth_shop_session_token_test.exs
+++ b/test/shopify_api/plugs/auth_shop_session_token_test.exs
@@ -1,0 +1,73 @@
+defmodule ShopifyAPI.Plugs.AuthShopSessionTokenTest do
+  # Not async: the exchange test asserts on captured logs, which would pick up output from tests
+  # running alongside it.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Plug.Test
+  import ShopifyAPI.Factory
+  import ShopifyAPI.SessionTokenSetup
+
+  alias Plug.Conn
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.Plugs.AuthShopSessionToken
+  alias ShopifyAPI.ShopServer
+
+  setup do
+    app = build(:app)
+    AppServer.set(app)
+    [app: app]
+  end
+
+  # Sends a request carrying a session token for the shop. A live online token is cached first,
+  # so the offline token alone decides the outcome.
+  defp call_plug(app, shop) do
+    [online_token: online_token] = online_token(%{shop: shop})
+
+    [jwt_session_token: session_token] =
+      jwt_session_token(%{app: app, shop: shop, online_token: online_token})
+
+    :get
+    |> conn("/")
+    |> Conn.put_req_header("authorization", "Bearer " <> session_token)
+    |> AuthShopSessionToken.call([])
+  end
+
+  test "assigns the shop's cached offline token", %{app: app} do
+    shop = build(:shop)
+    ShopServer.set(shop)
+    [offline_token: offline_token] = offline_token(%{shop: shop})
+
+    conn = call_plug(app, shop)
+
+    refute conn.halted
+    assert conn.assigns.auth_token == offline_token
+  end
+
+  test "exchanges the session token when the cached refresh token is dead", %{app: app} do
+    # `myshopify_domain/1` keeps only the host of the `dest` claim, so the exchange can't be
+    # pointed at Bypass. It goes to localhost, where nothing listens, so the request still ends
+    # in a 401 — the log is what shows an exchange was attempted instead of the dead token
+    # ending the request.
+    shop = %ShopifyAPI.Shop{domain: "localhost"}
+    ShopServer.set(shop)
+    dead = ShopifyAPI.Test.dead_token(shop_name: shop.domain, app_name: app.name)
+    AuthTokenServer.set(dead, false)
+
+    log = capture_log(fn -> assert %{status: 401} = call_plug(app, shop) end)
+
+    assert log =~ "exchanging session token"
+  end
+
+  test "raises rather than responding 401 when a refresh fails", %{app: app} do
+    # As above, the refresh can't be pointed at Bypass, and at localhost nothing answers it with a
+    # pair. A failed refresh is not a bad session, so it must not end in a 401.
+    shop = %ShopifyAPI.Shop{domain: "localhost"}
+    ShopServer.set(shop)
+    expired = ShopifyAPI.Test.expired_token(shop_name: shop.domain, app_name: app.name)
+    AuthTokenServer.set(expired, false)
+
+    assert_raise ShopifyAPI.TokenRefreshError, fn -> call_plug(app, shop) end
+  end
+end

--- a/test/shopify_api/refresh_concurrency_test.exs
+++ b/test/shopify_api/refresh_concurrency_test.exs
@@ -1,0 +1,267 @@
+defmodule ShopifyAPI.RefreshConcurrencyTest do
+  @moduledoc """
+  De-duplication, waiting and retry behaviour of `ShopifyAPI.Refresh`.
+
+  Tests drive real tasks against a Bypass server that holds its response open, so
+  interleaving is controlled by messages rather than by timing.
+  """
+
+  # Not async: shares the registry, the token cache, and the :refresh_retry setting.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Plug.Conn
+  alias ShopifyAPI.App
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.JSONSerializer
+  alias ShopifyAPI.Refresh
+
+  @app_name "refresh-concurrency-app"
+
+  setup do
+    # A client id of its own: the app cache is shared across the suite and
+    # `AppServer.get_by_client_id/1` only resolves when exactly one app matches.
+    AppServer.set(%App{
+      name: @app_name,
+      client_id: "concurrency-client-id",
+      client_secret: "client-secret"
+    })
+
+    previous_retry = Application.get_env(:shopify_api, :refresh_retry)
+
+    on_exit(fn ->
+      if previous_retry do
+        Application.put_env(:shopify_api, :refresh_retry, previous_retry)
+      else
+        Application.delete_env(:shopify_api, :refresh_retry)
+      end
+    end)
+
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, shop: "localhost:#{bypass.port}"}
+  end
+
+  defp cache(shop, attrs \\ []) do
+    token =
+      ShopifyAPI.Test.expired_token(
+        [shop_name: shop, app_name: @app_name, token: "shpat_current"] ++ attrs
+      )
+
+    AuthTokenServer.set(token, false)
+    token
+  end
+
+  defp pair_json do
+    JSONSerializer.encode!(%{
+      access_token: "shpat_refreshed",
+      expires_in: 3600,
+      refresh_token: "shprt_refreshed",
+      refresh_token_expires_in: 7_775_999
+    })
+  end
+
+  # A handler that announces itself and then blocks until the test releases it, so a refresh can
+  # be held in flight for as long as the test needs.
+  defp held_open(bypass) do
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+      send(test_pid, {:refresh_started, self()})
+
+      receive do
+        :release -> Conn.resp(conn, 200, pair_json())
+      after
+        5_000 -> Conn.resp(conn, 500, "test never released the handler")
+      end
+    end)
+  end
+
+  # Lets a held request finish, then waits for the background task that made it to exit. The
+  # cache is no signal of that: the task writes the new pair before it returns, and holds its
+  # registry key until it exits.
+  defp release(handler, shop) do
+    [{task, :refreshing}] = Registry.lookup(ShopifyAPI.RefreshRegistry, {shop, @app_name})
+    ref = Process.monitor(task)
+    send(handler, :release)
+    assert_receive {:DOWN, ^ref, :process, ^task, :normal}, 2_000
+  end
+
+  defp await_cached(shop, expected, attempts \\ 100) do
+    case AuthTokenServer.get(shop, @app_name) do
+      {:ok, %{token: ^expected}} ->
+        :ok
+
+      _ when attempts > 0 ->
+        Process.sleep(20)
+        await_cached(shop, expected, attempts - 1)
+
+      _ ->
+        :timeout
+    end
+  end
+
+  describe "background de-duplication" do
+    test "a second background refresh is not started while one is in flight", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      held_open(bypass)
+      token = cache(shop)
+
+      Refresh.run_in_background(token)
+      # The request is under way, so the task has already claimed the registry.
+      assert_receive {:refresh_started, handler}, 2_000
+
+      Refresh.run_in_background(token)
+      refute_receive {:refresh_started, _}, 300
+
+      release(handler, shop)
+    end
+
+    test "a refresh can be started again once the previous one has finished", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      # The registry entry is held by the task, so it goes away when the task does.
+      held_open(bypass)
+      token = cache(shop)
+
+      Refresh.run_in_background(token)
+      assert_receive {:refresh_started, first}, 2_000
+      release(first, shop)
+
+      Refresh.run_in_background(cache(shop))
+      assert_receive {:refresh_started, second}, 2_000
+      release(second, shop)
+    end
+  end
+
+  describe "awaiting a refresh in flight" do
+    test "waits for the running refresh rather than starting its own", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      held_open(bypass)
+      token = cache(shop)
+
+      Refresh.run_in_background(token)
+      assert_receive {:refresh_started, handler}, 2_000
+
+      # Release shortly, so await_or_run/1 genuinely blocks before the result arrives.
+      spawn(fn ->
+        Process.sleep(100)
+        send(handler, :release)
+      end)
+
+      assert {:ok, refreshed} = Refresh.await_or_run(token)
+      assert refreshed.token == "shpat_refreshed"
+
+      # One HTTP call served both the task and the waiter.
+      refute_receive {:refresh_started, _}, 300
+    end
+
+    test "refreshes itself when the wait times out", %{bypass: bypass, shop: shop} do
+      Application.put_env(:shopify_api, :refresh_wait_timeout_ms, 50)
+      on_exit(fn -> Application.delete_env(:shopify_api, :refresh_wait_timeout_ms) end)
+
+      test_pid = self()
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        :counters.add(counter, 1, 1)
+        send(test_pid, {:refresh_started, self()})
+
+        # Hold the first request open past the waiter's timeout; answer the rest at once.
+        if :counters.get(counter, 1) == 1 do
+          receive do
+            :release -> :ok
+          after
+            5_000 -> :ok
+          end
+        end
+
+        Conn.resp(conn, 200, pair_json())
+      end)
+
+      token = cache(shop)
+      Refresh.run_in_background(token)
+      assert_receive {:refresh_started, first}, 2_000
+
+      assert {:ok, refreshed} = Refresh.await_or_run(token)
+      assert refreshed.token == "shpat_refreshed"
+      assert :counters.get(counter, 1) == 2
+
+      # Let the held request finish, so no task outlives the Bypass server.
+      release(first, shop)
+    end
+  end
+
+  describe "retry and backoff" do
+    test "retries a transient failure and succeeds", %{bypass: bypass, shop: shop} do
+      Application.put_env(:shopify_api, :refresh_retry, attempts: 3, backoff_ms: 1)
+
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        :counters.add(counter, 1, 1)
+
+        case :counters.get(counter, 1) do
+          1 -> Conn.resp(conn, 503, "")
+          _ -> Conn.resp(conn, 200, pair_json())
+        end
+      end)
+
+      capture_log(fn ->
+        Refresh.run_in_background(cache(shop))
+        assert :ok = await_cached(shop, "shpat_refreshed")
+      end)
+
+      assert :counters.get(counter, 1) == 2
+    end
+
+    test "gives up after the configured attempts and leaves the token alone", %{
+      bypass: bypass,
+      shop: shop
+    } do
+      Application.put_env(:shopify_api, :refresh_retry, attempts: 2, backoff_ms: 1)
+
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+        :counters.add(counter, 1, 1)
+        Conn.resp(conn, 503, "")
+      end)
+
+      original = cache(shop)
+
+      log =
+        capture_log(fn ->
+          Refresh.run_in_background(original)
+          # Long enough for both attempts and the backoff between them.
+          Process.sleep(400)
+        end)
+
+      assert :counters.get(counter, 1) == 2
+      assert log =~ "gave up refreshing"
+      assert {:ok, ^original} = AuthTokenServer.get(shop, @app_name)
+    end
+
+    test "does not retry a token naming an app that is not registered", %{shop: shop} do
+      Application.put_env(:shopify_api, :refresh_retry, attempts: 3, backoff_ms: 1)
+
+      token = ShopifyAPI.Test.expired_token(shop_name: shop, app_name: "never-registered")
+
+      log =
+        capture_log(fn ->
+          Refresh.run_in_background(token)
+          Process.sleep(200)
+        end)
+
+      # A config error, not a blip: it should surface immediately rather than after backoff.
+      refute log =~ "gave up refreshing"
+      assert log =~ "not a registered app"
+    end
+  end
+end

--- a/test/shopify_api/refresh_test.exs
+++ b/test/shopify_api/refresh_test.exs
@@ -1,0 +1,107 @@
+defmodule ShopifyAPI.RefreshTest do
+  # Async-safe: every token here is keyed on an app name no other test uses, and the assertions
+  # filter the shared cache down to it.
+  use ExUnit.Case, async: true
+
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.Refresh
+
+  # Each test gets its own app name to isolate within the shared cache.
+  setup context do
+    {:ok, app: "refresh-sweep-#{:erlang.phash2(context.test)}"}
+  end
+
+  defp cache(app, shop_name, attrs) do
+    token = ShopifyAPI.Test.expiring_token([shop_name: shop_name, app_name: app] ++ attrs)
+    AuthTokenServer.set(token, false)
+    token
+  end
+
+  defp in_days(days), do: DateTime.shift(DateTime.utc_now(), day: days)
+
+  defp swept(app, days) do
+    Duration.new!(day: days)
+    |> Refresh.shops_needing_refresh()
+    |> Enum.filter(&(&1.app_name == app))
+    |> Enum.map(& &1.shop_name)
+    |> Enum.sort()
+  end
+
+  describe "shops_needing_refresh/1" do
+    test "selects pairs older than the given age", %{app: app} do
+      # Age is read off the access token's expiry, which every refresh sets an hour out.
+      cache(app, "stale.myshopify.com", token_expires_at: in_days(-30))
+      cache(app, "fresh.myshopify.com", token_expires_at: in_days(-5))
+
+      assert swept(app, 28) == ["stale.myshopify.com"]
+    end
+
+    test "leaves a pair refreshed moments ago alone", %{app: app} do
+      # Its access token expires in the future, so the pair is barely minutes old.
+      cache(app, "just-refreshed.myshopify.com", token_expires_at: in_days(1))
+
+      assert swept(app, 28) == []
+    end
+
+    test "ignores permanent tokens", %{app: app} do
+      cache(app, "permanent.myshopify.com",
+        refresh_token: nil,
+        token_expires_at: nil,
+        refresh_token_expires_at: nil
+      )
+
+      assert swept(app, 1) == []
+    end
+
+    test "ignores refresh tokens that are past their own expiry", %{app: app} do
+      # Dead beyond replay, so a sweep should not spend a request discovering that.
+      cache(app, "lapsed.myshopify.com",
+        token_expires_at: in_days(-95),
+        refresh_token_expires_at: in_days(-5)
+      )
+
+      assert swept(app, 28) == []
+    end
+
+    test "includes a token with no access-token expiry to date it by", %{app: app} do
+      cache(app, "no-expiry.myshopify.com", token_expires_at: nil)
+
+      assert swept(app, 28) == ["no-expiry.myshopify.com"]
+    end
+  end
+
+  describe "await_or_run/1" do
+    test "uses the cached token when ours has already been replaced", %{app: app} do
+      # When the cache already holds a newer token, `await_or_run/1` returns it instead of
+      # refreshing with the stale one whose refresh token may already be spent.
+      stale =
+        ShopifyAPI.Test.expiring_token(
+          shop_name: "raced.myshopify.com",
+          app_name: app,
+          token: "shpat_stale"
+        )
+
+      replacement = %{stale | token: "shpat_replacement"}
+      AuthTokenServer.set(replacement, false)
+
+      # The app is deliberately not registered in AppServer, so any attempt to actually refresh
+      # raises rather than quietly passing.
+      assert {:ok, ^replacement} = Refresh.await_or_run(stale)
+    end
+  end
+
+  describe "run/1" do
+    test "refuses a permanent token", %{app: app} do
+      token = %AuthToken{shop_name: "permanent.myshopify.com", app_name: app}
+
+      assert_raise ArgumentError, ~r/no refresh token/, fn -> Refresh.run(token) end
+    end
+
+    test "refuses a token naming an app that is not registered" do
+      token = ShopifyAPI.Test.expiring_token(app_name: "never-registered-app")
+
+      assert_raise ArgumentError, ~r/not a registered app/, fn -> Refresh.run(token) end
+    end
+  end
+end


### PR DESCRIPTION
Shopify has required expiring offline access tokens of new public apps since April 2026 and stops accepting permanent ones on 1 January 2027, after which the Admin API answers 403. An expiring token lives an hour and arrives with a refresh token; refreshing rotates both halves at once and the two are only ever valid together. This library modelled only permanent tokens: the struct had nowhere to put an expiry or a refresh token, AuthTokenServer never evicted or refreshed, and both AuthRequest paths dropped the expiry fields on the floor.

Both shapes now coexist, which they have to — the rollout runs for months, and a nil refresh_token is what marks a shop as not yet migrated.

Reading tokens

AuthToken.fetch/2 is what application code should read through, and returns a token that is ready to use. AuthTokenServer.get/2 is unchanged and still returns whatever the cache holds, which for an expiring token may expired. A permanent token comes back untouched; one close to expiry comes back as-is with a refresh started in the background; an expired one is refreshed before returning, and only that caller waits, and only for that shop.

A token with any life left is returned whatever state its refresh token is in, and renewal is only started when it could succeed — an access token is good for the rest of its hour regardless of its refresh token. status/2 answers by the same rule without refreshing anything, so the two cannot disagree about a shop.

Two errors are returned and everything else raises. {:error, :not_found} and {:error, :needs_reacquisition} are conditions a caller can act on; a Shopify 5xx, a timeout or a rate limit is not, so it raises and an Oban job backs off, a Phoenix request 500s, and a webhook gets redelivered without any caller having to remember to re-raise. This mirrors System.cmd/3, where a command that runs and fails returns a value but a missing executable raises.

Refreshing

ShopifyAPI.Refresh owns when a refresh happens and how often it is retried; AuthRequest.refresh_offline_access_token/2 is the single HTTP call underneath. A Registry holds the refresh in flight for each shop and app, so a second is not started while the first runs — an optimisation, not a correctness mechanism, since concurrent refreshes return the same pair.

Only background refreshes are de-duplicated. A caller holding an expired token refreshes in its own process without registering, so several arriving together each make their own request rather than queueing the urgent path behind a supervised process, which would be more brittle and harder to reason about. The redundant requests return the same pair and write the same value.

Every path that falls back to refreshing re-reads the cache first. A refresh that timed out may have succeeded a moment later and had its result spent by someone else, and presenting a refresh token whose replacement has been used is the one case Shopify's replay does not cover.

RefreshSupervisor is a subtree of its own so refreshes failing in bursts against a Shopify outage exhaust their own restart budget rather than the one shared by the four caches. It starts unconditionally: expiring gates acquisition only, and a deployment that has turned it off must still refresh shops that already migrated. That is what makes the flag safe to turn off.

Writing tokens

AuthTokenServer.set/2 now persists before it writes to the cache, and treats a failure as fatal. The old ordering could leave the cache holding a pair storage never received; the next refresh spends that pair, closing the replay window on the one storage still has, and the shop needs a full reinstall. Persisting first means a failed write leaves both sides on the old pair, which still refreshes.

Logging

Failures at the token endpoint were logged by inspecting the whole HTTPoison result, which carries the request body and so the client secret and whichever token was being traded. They now log the status and response body only — Shopify's error and description, and no credentials. Worth calling out because re-acquisition routes through that same exchange, so those lines fire far more often than before.

Breaking changes

  - AuthTokenServer.get/2 returns {:error, :not_found} where it returned a formatted string. Check for guards matching a binary error term.
  - AuthTokenServer.set/2 raises when the persistence callback fails or returns {:error, _}. A callback that logs and returns must now raise, and must write all three new columns — dropping refresh_token looks like a successful write and kills the shop ninety days later.

Departures from the design doc

  - JWTSessionToken.get_offline_token/2 reads through fetch/2. The doc specifies a raw cache read, which treats "a token exists" as "a token works" and hands the admin plug a dead token to take a 401 on. Its stated rationale does not hold: a successful refresh is returned rather than exchanged, and a dead refresh token reports itself without an HTTP call.
  - Refresh.shops_needing_refresh/1 selects on the age of the pair rather than on remaining refresh-token life. The binding constraint is the thirty-day replay window, not the ninety-day expiry, so a sweep that waits for expiry protects nothing.
  - No swappable exchange client. The suite stubs Shopify with Bypass, which exercises the real HTTP path; ShopifyAPI.Test ships the token-state builders consumer tests actually need.
  - No x-request-id logging.

Design doc:
https://linear.app/orbitapps/document/expiring-offline-access-tokens-elixir-library-design-dd1f5dcf51fe

Shopify:
https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens https://shopify.dev/changelog/expiring-offline-access-tokens-required-for-all-public-apps-as-of-january-1-2027 https://shopify.dev/changelog/more-resilient-refreshes-for-expiring-offline-access-tokens

Refs: CR-2681, CR-2679